### PR TITLE
Allowing for versioned brew Formula w/ public repo

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,3 +20,19 @@ archives:
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
+
+brews:
+  - repository:
+      owner: Metronome-Industries
+      name: homebrew-metronome
+      branch: main
+    folder: Formula
+    homepage: https://github.com/Metronome-Industries/{{ .ProjectName }} 
+    dependencies:
+      - name: metronome-industries/metronome/substrate-tools
+      - name: kubectl
+      - name: kubectx
+      - name: awscli
+        type: optional
+    download_strategy: GitHubPrivateRepoAssetDownloadStrategy
+    custom_require: "../extensions/custom_download_strategy"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -34,5 +34,3 @@ brews:
       - name: kubectx
       - name: awscli
         type: optional
-    download_strategy: GitHubPrivateRepoAssetDownloadStrategy
-    custom_require: "../extensions/custom_download_strategy"

--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@ Under the hood `quikstrate` is caching and reusing the credentials returned by s
 ## Installing
 
 ```bash
+# probably already done
+brew tap metronome-industries/metronome
+
 brew update
-export HOMEBREW_GITHUB_API_TOKEN=$GITHUB_TOKEN
-brew install metronome-industries/metronome/quikstrate
+brew install quikstrate
 ```
 
 ## Usage
@@ -39,8 +41,3 @@ for publishing to the `metronome-industries/homebrew-metronome` tap.
 * <https://github.com/bitfield/script>
 * <https://github.com/aws/aws-sdk-go-v2>
 * <https://goreleaser.com/>
-
-## TODOs
-
-1. command to ensure kubeconfig/aws config files are correct
-2. configure kubeconfig to ignore AWS_* environment variables

--- a/README.md
+++ b/README.md
@@ -7,11 +7,9 @@ Under the hood `quikstrate` is caching and reusing the credentials returned by s
 ## Installing
 
 ```bash
-# probably already done
-brew tap metronome-industries/metronome
-
 brew update
-brew install quikstrate
+export HOMEBREW_GITHUB_API_TOKEN=$GITHUB_TOKEN
+brew install metronome-industries/metronome/quikstrate
 ```
 
 ## Usage
@@ -31,7 +29,8 @@ quikstrate configure
 
 ## Deployment
 
-The `SSH Key - goreleaser` in 1Password was created and added (per [documentation](https://circleci.com/docs/github-integration/#create-additional-github-ssh-keys)) as a Github deploy key with write access and a CircleCI deploy key to allow for repository tagging and release artifact creation.
+The `SSH Key - goreleaser` in 1Password was created and added (per [documentation](https://circleci.com/docs/github-integration/#create-additional-github-ssh-keys)) as a Github deploy key with write access and a CircleCI deploy key.  The CircleCI `goreleaser` context contains a classic GITHUB_TOKEN with `delete:packages, repo, write:packages` permissions
+for publishing to the `metronome-industries/homebrew-metronome` tap.
 
 ## Links
 
@@ -40,3 +39,8 @@ The `SSH Key - goreleaser` in 1Password was created and added (per [documentatio
 * <https://github.com/bitfield/script>
 * <https://github.com/aws/aws-sdk-go-v2>
 * <https://goreleaser.com/>
+
+## TODOs
+
+1. command to ensure kubeconfig/aws config files are correct
+2. configure kubeconfig to ignore AWS_* environment variables


### PR DESCRIPTION
Reverts Metronome-Industries/quikstrate#9 and updated Formula/README for public github artifacts.

There aren't any security concerns here as:
1. only gnomers have write access to repo
2. circleci has been configured to *not* build any PRs from forked repos