### PR TITLE
Update substrate command for 2024.01 upgrade

### DIFF
--- a/internal/creds/cmd_accounts.go
+++ b/internal/creds/cmd_accounts.go
@@ -41,7 +41,7 @@ func refreshAccounts(file string) (accountList AccountList, err error) {
 	}
 	defaultCreds.SetEnv()
 
-	byteValue, err := script.NewPipe().WithStderr(os.Stderr).Exec("substrate account list -format json").Bytes()
+	byteValue, err := script.NewPipe().WithStderr(os.Stderr).Exec("substrate account list --format json").Bytes()
 	if err != nil {
 		return
 	}

--- a/internal/creds/cmd_accounts.go
+++ b/internal/creds/cmd_accounts.go
@@ -41,7 +41,7 @@ func refreshAccounts(file string) (accountList AccountList, err error) {
 	}
 	defaultCreds.SetEnv()
 
-	byteValue, err := script.NewPipe().WithStderr(os.Stderr).Exec("substrate accounts -format json").Bytes()
+	byteValue, err := script.NewPipe().WithStderr(os.Stderr).Exec("substrate accounts list -format json").Bytes()
 	if err != nil {
 		return
 	}

--- a/internal/creds/cmd_accounts.go
+++ b/internal/creds/cmd_accounts.go
@@ -41,7 +41,7 @@ func refreshAccounts(file string) (accountList AccountList, err error) {
 	}
 	defaultCreds.SetEnv()
 
-	byteValue, err := script.NewPipe().WithStderr(os.Stderr).Exec("substrate accounts list -format json").Bytes()
+	byteValue, err := script.NewPipe().WithStderr(os.Stderr).Exec("substrate account list -format json").Bytes()
 	if err != nil {
 		return
 	}

--- a/internal/creds/credentials.go
+++ b/internal/creds/credentials.go
@@ -94,11 +94,10 @@ func refreshCredentials(role RoleData, file string) (Credentials, error) {
 func getCredentials(role RoleData) (creds Credentials, err error) {
 	var cmd string
 	if (role == RoleData{}) {
-		// if you don't run with "-force" and your env creds are not expired, substrate will output a non-JSON response
-		cmd = "substrate credentials -format json -force"
+		cmd = "substrate credentials --format json --force"
 	} else {
 		ensureAWSEnvSet()
-		cmd = fmt.Sprintf("substrate assume-role -environment %s -domain %s -quality %s -role %s -format json", role.Environment, role.Domain, role.Quality, role.Role)
+		cmd = fmt.Sprintf("substrate assume-role --environment %s --domain %s --quality %s --role %s --format json", role.Environment, role.Domain, role.Quality, role.Role)
 	}
 	log.Print("running: ", cmd)
 	byteValue, err := script.NewPipe().WithStderr(os.Stderr).Exec(cmd).Bytes()


### PR DESCRIPTION
The `accounts` command changed to `account list` in substrate `2024.01`. See https://docs.substrate.tools/substrate/ref/command-changes-2024.01