### PR TITLE
Fix bug in credentials command introduced by substrate 2023.12 upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 quikstrate
 dist/
+.idea

--- a/internal/creds/credentials.go
+++ b/internal/creds/credentials.go
@@ -94,7 +94,8 @@ func refreshCredentials(role RoleData, file string) (Credentials, error) {
 func getCredentials(role RoleData) (creds Credentials, err error) {
 	var cmd string
 	if (role == RoleData{}) {
-		cmd = "substrate credentials -format json"
+		// if you don't run with "-force" and your env creds are not expired, substrate will output a non-JSON response
+		cmd = "substrate credentials -format json -force"
 	} else {
 		ensureAWSEnvSet()
 		cmd = fmt.Sprintf("substrate assume-role -environment %s -domain %s -quality %s -role %s -format json", role.Environment, role.Domain, role.Quality, role.Role)


### PR DESCRIPTION
`substrate credentials` will return a non-JSON response if creds in your local environment are not expired. Adding `-force` fixes this.