### PR TITLE
Add IAM Identity Center as an optional credential source

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -31,7 +31,10 @@ func init() {
 	configureCmd.Flags().BoolP("clean", "c", false, "removes existing config files before configuring")
 	configureCmd.Flags().Bool("check", false, "checks if this command has been run before")
 	configureCmd.Flags().BoolP("dryrun", "d", false, "removes existing config files before configuring")
+	configureCmd.Flags().Bool("use-identitycenter", false, "use Metronome IAM Identity Center as the credential source (write Identity Center block to ~/.aws/config)")
+	configureCmd.Flags().Bool("use-substrate", false, "use Substrate as the credential source (pair with --clean to hard delete Identity Center settings)")
 	configureCmd.MarkFlagsMutuallyExclusive("clean", "dryrun", "check")
+	configureCmd.MarkFlagsMutuallyExclusive("use-identitycenter", "use-substrate")
 	configureCmd.Flags().String("aws-region", "us-west-2", "aws region to configure")
 	var defaultEnvs []string
 	for _, env := range creds.EnvironmentMap {

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21.3
 require (
 	github.com/aws/aws-sdk-go-v2 v1.23.1
 	github.com/aws/aws-sdk-go-v2/config v1.25.5
+	github.com/aws/aws-sdk-go-v2/service/sso v1.17.3
 	github.com/aws/aws-sdk-go-v2/service/sts v1.25.4
 	github.com/bitfield/script v0.22.0
 	github.com/bmatcuk/doublestar/v4 v4.6.1
@@ -28,7 +29,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.7.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.10.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.10.4 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sso v1.17.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.20.1 // indirect
 	github.com/aws/smithy-go v1.17.0 // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect

--- a/internal/creds/cmd_assume.go
+++ b/internal/creds/cmd_assume.go
@@ -12,26 +12,23 @@ func AssumeCmd(cmd *cobra.Command, args []string) {
 	force, _ := cmd.Flags().GetBool("force")
 	management, _ := cmd.Flags().GetBool("management")
 	special, _ := cmd.Flags().GetString("special")
-	roleOverride, _ := cmd.Flags().GetString("role")
+	roleOverride := cmd.Flag("role").Value.String()
 
 	var roleData RoleData
-
 	switch {
 	case management:
-		// Special accounts default to engineersreadonly; pass --role admin for write access.
 		roleData = RoleData{SpecialAccount: "management", Role: roleOverride}
 	case special != "":
 		roleData = RoleData{SpecialAccount: special, Role: roleOverride}
 	default:
 		env := cmd.Flag("env").Value.String()
 		domain := cmd.Flag("domain").Value.String()
-		quality := cmd.Flag("quality").Value.String()
 		if env == "" || domain == "" {
 			cmd.Usage()
 			os.Exit(1)
 		}
 		var ok bool
-		roleData, ok = NewRoleData(env, domain, quality, roleOverride)
+		roleData, ok = NewRoleData(env, domain, cmd.Flag("quality").Value.String(), roleOverride)
 		if !ok {
 			log.Fatalf("unknown environment %q", env)
 		}
@@ -59,6 +56,7 @@ func NewRoleData(environment, domain, quality, role string) (RoleData, bool) {
 	if quality == "" {
 		quality = EnvironmentMap[environment].DefaultQuality
 	}
+
 	return RoleData{
 		Environment: environment,
 		Domain:      domain,

--- a/internal/creds/cmd_assume.go
+++ b/internal/creds/cmd_assume.go
@@ -12,23 +12,26 @@ func AssumeCmd(cmd *cobra.Command, args []string) {
 	force, _ := cmd.Flags().GetBool("force")
 	management, _ := cmd.Flags().GetBool("management")
 	special, _ := cmd.Flags().GetString("special")
-	roleOverride := cmd.Flag("role").Value.String()
+	roleOverride, _ := cmd.Flags().GetString("role")
 
 	var roleData RoleData
+
 	switch {
 	case management:
+		// Special accounts default to engineersreadonly; pass --role admin for write access.
 		roleData = RoleData{SpecialAccount: "management", Role: roleOverride}
 	case special != "":
 		roleData = RoleData{SpecialAccount: special, Role: roleOverride}
 	default:
 		env := cmd.Flag("env").Value.String()
 		domain := cmd.Flag("domain").Value.String()
+		quality := cmd.Flag("quality").Value.String()
 		if env == "" || domain == "" {
 			cmd.Usage()
 			os.Exit(1)
 		}
 		var ok bool
-		roleData, ok = NewRoleData(env, domain, cmd.Flag("quality").Value.String(), roleOverride)
+		roleData, ok = NewRoleData(env, domain, quality, roleOverride)
 		if !ok {
 			log.Fatalf("unknown environment %q", env)
 		}
@@ -56,7 +59,6 @@ func NewRoleData(environment, domain, quality, role string) (RoleData, bool) {
 	if quality == "" {
 		quality = EnvironmentMap[environment].DefaultQuality
 	}
-
 	return RoleData{
 		Environment: environment,
 		Domain:      domain,

--- a/internal/creds/cmd_configure.go
+++ b/internal/creds/cmd_configure.go
@@ -28,10 +28,10 @@ var (
 	binaryName = "quikstrate"
 	binaryPath string
 
+	// match fmt.Sprintf("%s-%s", environment, cluster.Domain)
 	kubeConfigSkips = []string{}
 
-	// Substrate's "special" domains beyond management — audit/deploy/network each get their own AWS profile.
-	specialDomains = []string{"audit", "deploy", "network"}
+	specialDomains = []string{"audit", "deploy", "network"} // management is special
 )
 
 func ConfigureCmd(cmd *cobra.Command, args []string) {
@@ -107,12 +107,13 @@ func configureAWSConfig(environments, domains []string) error {
 			setAWSProfile(profile, fmt.Sprintf("\"%s assume -e %s -d %s -f json\"", binaryPath, environment, domain), awsRegion)
 		}
 	}
+
 	setAWSProfile("management", fmt.Sprintf("\"%s assume --management -f json\"", binaryPath), awsRegion)
 	for _, domain := range specialDomains {
 		setAWSProfile(domain, fmt.Sprintf("\"%s assume --special %s -f json\"", binaryPath, domain), awsRegion)
 	}
-	setAWSConfigValue("default", "credential_process", fmt.Sprintf("\"%s credentials -f json\"", binaryPath))
 
+	setAWSConfigValue("default", "credential_process", fmt.Sprintf("\"%s credentials -f json\"", binaryPath))
 	setAWSConfigValue("default", "region", awsRegion)
 	return nil
 }
@@ -151,6 +152,7 @@ func configureKubeConfig(environments, domains []string) error {
 				continue
 			}
 
+			// aws eks update-config
 			cmd := fmt.Sprintf("aws eks update-kubeconfig --alias %[1]s-%[3]s --user-alias %[1]s-%[3]s --name %[3]s --profile %[1]s-%[2]s", environment, cluster.Domain, cluster.Name)
 			if configDryrun {
 				log.Printf("export AWS_PROFILE=%s\n", fmt.Sprintf("%s-%s", environment, cluster.Domain))
@@ -166,7 +168,6 @@ func configureKubeConfig(environments, domains []string) error {
 	}
 	return nil
 }
-
 func getenv(key, fallback string) string {
 	value := os.Getenv(key)
 	if len(value) == 0 {

--- a/internal/creds/cmd_configure.go
+++ b/internal/creds/cmd_configure.go
@@ -19,23 +19,27 @@ var (
 	awsConfigFile  string = getenv("AWS_CONFIG_FILE", filepath.Join(home, ".aws/config"))
 	kubeConfigFile string = getenv("KUBECONFIG", filepath.Join(home, ".kube/config"))
 
-	configDryrun bool
-	configClean  bool
-	awsRegion    string
+	configDryrun            bool
+	configClean             bool
+	configUseIdentityCenter bool
+	configUseSubstrate      bool
+	awsRegion               string
 
 	binaryName = "quikstrate"
 	binaryPath string
 
-	// match fmt.Sprintf("%s-%s", environment, cluster.Domain)
 	kubeConfigSkips = []string{}
 
-	specialDomains = []string{"audit", "deploy", "network"} // management is special
+	// Substrate's "special" domains beyond management — audit/deploy/network each get their own AWS profile.
+	specialDomains = []string{"audit", "deploy", "network"}
 )
 
 func ConfigureCmd(cmd *cobra.Command, args []string) {
 	configClean, _ = strconv.ParseBool(cmd.Flag("clean").Value.String())
 	configDryrun, _ = strconv.ParseBool(cmd.Flag("dryrun").Value.String())
 	configCheck, _ := strconv.ParseBool(cmd.Flag("check").Value.String())
+	configUseIdentityCenter, _ = cmd.Flags().GetBool("use-identitycenter")
+	configUseSubstrate, _ = cmd.Flags().GetBool("use-substrate")
 	awsRegion = cmd.Flag("aws-region").Value.String()
 	environments := strings.Split(cmd.Flag("environments").Value.String(), ",")
 	domains := strings.Split(cmd.Flag("domains").Value.String(), ",")
@@ -55,6 +59,18 @@ func ConfigureCmd(cmd *cobra.Command, args []string) {
 		}
 		log.Print("quikstrate configured correctly...")
 		os.Exit(0)
+	}
+
+	if !configDryrun {
+		if configUseIdentityCenter {
+			if err := writeQuikstrateConfig(quikstrateConfig{CredentialSource: "identitycenter"}); err != nil {
+				log.Fatal(err)
+			}
+		} else if configUseSubstrate {
+			if err := writeQuikstrateConfig(quikstrateConfig{CredentialSource: "substrate"}); err != nil {
+				log.Fatal(err)
+			}
+		}
 	}
 
 	err = configureAWSConfig(environments, domains)
@@ -77,19 +93,26 @@ func configureAWSConfig(environments, domains []string) error {
 
 	// reverse order so staging is before prod
 	sort.Sort(sort.Reverse(sort.StringSlice(environments)))
+
+	if configUseIdentityCenter || useIDC() {
+		// Write the sso-session block so engineers can run `aws sso login --sso-session metronome` on first use.
+		if err := writeSSOSessionConfig(metronomeIDCSessionName, metronomeIDCStartURL, metronomeIDCRegion); err != nil {
+			return err
+		}
+	}
+
 	for _, environment := range environments {
 		for _, domain := range domains {
 			profile := fmt.Sprintf("%s-%s", environment, domain)
 			setAWSProfile(profile, fmt.Sprintf("\"%s assume -e %s -d %s -f json\"", binaryPath, environment, domain), awsRegion)
 		}
 	}
-
 	setAWSProfile("management", fmt.Sprintf("\"%s assume --management -f json\"", binaryPath), awsRegion)
 	for _, domain := range specialDomains {
 		setAWSProfile(domain, fmt.Sprintf("\"%s assume --special %s -f json\"", binaryPath, domain), awsRegion)
 	}
-
 	setAWSConfigValue("default", "credential_process", fmt.Sprintf("\"%s credentials -f json\"", binaryPath))
+
 	setAWSConfigValue("default", "region", awsRegion)
 	return nil
 }
@@ -128,7 +151,6 @@ func configureKubeConfig(environments, domains []string) error {
 				continue
 			}
 
-			// aws eks update-config
 			cmd := fmt.Sprintf("aws eks update-kubeconfig --alias %[1]s-%[3]s --user-alias %[1]s-%[3]s --name %[3]s --profile %[1]s-%[2]s", environment, cluster.Domain, cluster.Name)
 			if configDryrun {
 				log.Printf("export AWS_PROFILE=%s\n", fmt.Sprintf("%s-%s", environment, cluster.Domain))
@@ -144,6 +166,7 @@ func configureKubeConfig(environments, domains []string) error {
 	}
 	return nil
 }
+
 func getenv(key, fallback string) string {
 	value := os.Getenv(key)
 	if len(value) == 0 {

--- a/internal/creds/cmd_configure.go
+++ b/internal/creds/cmd_configure.go
@@ -95,7 +95,6 @@ func configureAWSConfig(environments, domains []string) error {
 	sort.Sort(sort.Reverse(sort.StringSlice(environments)))
 
 	if configUseIdentityCenter || useIDC() {
-		// Write the sso-session block so engineers can run `aws sso login --sso-session metronome` on first use.
 		if err := writeSSOSessionConfig(metronomeIDCSessionName, metronomeIDCStartURL, metronomeIDCRegion); err != nil {
 			return err
 		}

--- a/internal/creds/cmd_credentials.go
+++ b/internal/creds/cmd_credentials.go
@@ -11,15 +11,16 @@ func CredentialsCmd(cmd *cobra.Command, args []string) {
 	format := cmd.Flag("format").Value.String()
 	force := cmd.Flag("force").Value.String()
 	check := cmd.Flag("check").Value.String()
-
 	if check == "true" {
 		checkCredentials()
 	}
 
-	var creds Credentials
-	var err error
+	var (
+		creds Credentials
+		err   error
+	)
 	if force == "true" {
-		creds, err = getAndWriteCredentials(RoleData{}, DefaultCredsFile)
+		creds, err = getAndWriteCredentials(RoleData{}, defaultCredsFile())
 	} else {
 		creds, err = getDefaultCredentials()
 	}
@@ -29,12 +30,8 @@ func CredentialsCmd(cmd *cobra.Command, args []string) {
 	creds.Print(format)
 }
 
-func getDefaultCredentials() (Credentials, error) {
-	return refreshCredentials(RoleData{}, DefaultCredsFile)
-}
-
 func checkCredentials() {
-	creds, err := getCredsFromFile(DefaultCredsFile)
+	creds, err := getCredsFromFile(defaultCredsFile())
 	if err != nil || creds.needsRefresh() {
 		os.Exit(1)
 	}

--- a/internal/creds/cmd_credentials.go
+++ b/internal/creds/cmd_credentials.go
@@ -11,14 +11,13 @@ func CredentialsCmd(cmd *cobra.Command, args []string) {
 	format := cmd.Flag("format").Value.String()
 	force := cmd.Flag("force").Value.String()
 	check := cmd.Flag("check").Value.String()
+
 	if check == "true" {
 		checkCredentials()
 	}
 
-	var (
-		creds Credentials
-		err   error
-	)
+	var creds Credentials
+	var err error
 	if force == "true" {
 		creds, err = getAndWriteCredentials(RoleData{}, defaultCredsFile())
 	} else {

--- a/internal/creds/config.go
+++ b/internal/creds/config.go
@@ -31,10 +31,10 @@ func writeQuikstrateConfig(cfg quikstrateConfig) error {
 }
 
 // useIDC reports whether quikstrate should use Metronome IAM Identity Center.
-// Priority: USE_IDC env var > ~/.quikstrate/config.json > default (false = use Substrate).
+// Priority: USE_SUBSTRATE env var > ~/.quikstrate/config.json > default (Substrate).
 func useIDC() bool {
-	if v := os.Getenv("USE_IDC"); v != "" {
-		return v == "true"
+	if os.Getenv("USE_SUBSTRATE") == "true" {
+		return false
 	}
 	return readQuikstrateConfig().CredentialSource == "identitycenter"
 }

--- a/internal/creds/config.go
+++ b/internal/creds/config.go
@@ -1,0 +1,40 @@
+package creds
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+var quikstrateConfigFile = filepath.Join(home, ".quikstrate", "config.json")
+
+type quikstrateConfig struct {
+	CredentialSource string `json:"credential_source"`
+}
+
+func readQuikstrateConfig() quikstrateConfig {
+	data, err := os.ReadFile(quikstrateConfigFile)
+	if err != nil {
+		return quikstrateConfig{}
+	}
+	var cfg quikstrateConfig
+	json.Unmarshal(data, &cfg)
+	return cfg
+}
+
+func writeQuikstrateConfig(cfg quikstrateConfig) error {
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(quikstrateConfigFile, data, 0644)
+}
+
+// useIDC reports whether quikstrate should use Metronome IAM Identity Center.
+// Priority: USE_IDC env var > ~/.quikstrate/config.json > default (false = use Substrate).
+func useIDC() bool {
+	if v := os.Getenv("USE_IDC"); v != "" {
+		return v == "true"
+	}
+	return readQuikstrateConfig().CredentialSource == "identitycenter"
+}

--- a/internal/creds/credentials.go
+++ b/internal/creds/credentials.go
@@ -127,7 +127,7 @@ func getIDCCredentials(role RoleData) (Credentials, error) {
 		if err != nil {
 			return Credentials{}, err
 		}
-		return getIDCRoleCredentials(accountID, roleName, role.Role == "", role.SpecialAccount)
+		return getIDCRoleCredentials(accountID, roleName, role.SpecialAccount)
 	}
 
 	accountID, err := lookupServiceAccountID(role.Domain, role.Environment)
@@ -135,21 +135,13 @@ func getIDCCredentials(role RoleData) (Credentials, error) {
 		return Credentials{}, err
 	}
 	roleName := normalizeIDCRole(role.Role, role.Environment)
-	return getIDCRoleCredentials(accountID, roleName, role.Role == "", fmt.Sprintf("%s-%s", role.Environment, role.Domain))
+	return getIDCRoleCredentials(accountID, roleName, fmt.Sprintf("%s-%s", role.Environment, role.Domain))
 }
 
-// getIDCRoleCredentials fetches IDC credentials, falling back to idcRoleReadOnly
-// if admin was the environment default and isn't available.
-func getIDCRoleCredentials(accountID, roleName string, autoFallback bool, label string) (Credentials, error) {
+func getIDCRoleCredentials(accountID, roleName, label string) (Credentials, error) {
 	creds, err := getMetronomeSSORoleCredentials(accountID, roleName)
 	if err == nil {
 		return creds, nil
-	}
-	if autoFallback && roleName == idcRoleAdmin && errors.Is(err, errPermissionSetNotAvailable) {
-		log.Printf("[quikstrate] %s not available for %s, using %s\n", idcRoleAdmin, label, idcRoleReadOnly)
-		if creds, err = getMetronomeSSORoleCredentials(accountID, idcRoleReadOnly); err == nil {
-			return creds, nil
-		}
 	}
 	if errors.Is(err, errPermissionSetNotAvailable) {
 		return Credentials{}, fmt.Errorf("no %q permission set for %s", roleName, label)
@@ -179,8 +171,10 @@ func idcRoleForEnvironment(environment string) string {
 // This ensures existing scripts that pass --role Administrator or Auditor keep working.
 func normalizeIDCRole(role, environment string) string {
 	switch role {
-	case "", substrateRoleReadOnly:
+	case "":
 		return idcRoleForEnvironment(environment)
+	case substrateRoleReadOnly:
+		return idcRoleReadOnly
 	case substrateRoleAdmin:
 		return idcRoleAdmin
 	default:
@@ -200,7 +194,7 @@ func substrateBaseCredentials() (Credentials, error) {
 }
 
 func substrateAssumeRole(role RoleData) (Credentials, error) {
-	baseCreds, err := substrateBaseCredentials()
+	baseCreds, err := refreshCredentials(RoleData{}, DefaultCredsFile)
 	if err != nil {
 		return Credentials{}, err
 	}
@@ -218,7 +212,7 @@ func substrateAssumeRole(role RoleData) (Credentials, error) {
 }
 
 func substrateSpecialCredentials(name string) (Credentials, error) {
-	baseCreds, err := substrateBaseCredentials()
+	baseCreds, err := refreshCredentials(RoleData{}, DefaultCredsFile)
 	if err != nil {
 		return Credentials{}, err
 	}

--- a/internal/creds/credentials.go
+++ b/internal/creds/credentials.go
@@ -15,6 +15,13 @@ import (
 
 const defaultRefreshTrigger = 5 * time.Minute
 
+const (
+	idcRoleAdmin    = "admin"
+	idcRoleReadOnly = "engineersreadonly"
+	substrateRoleAdmin    = "Administrator"
+	substrateRoleReadOnly = "Auditor"
+)
+
 type Credentials struct {
 	AccessKeyId     string    `json:"AccessKeyId"`
 	SecretAccessKey string    `json:"SecretAccessKey"`
@@ -85,6 +92,7 @@ func getCredsFromFile(file string) (Credentials, error) {
 
 func refreshCredentials(role RoleData, file string) (Credentials, error) {
 	creds, _ := getCredsFromFile(file)
+
 	if creds.needsRefresh() {
 		return getAndWriteCredentials(role, file)
 	}
@@ -101,9 +109,6 @@ func getAndWriteCredentials(role RoleData, file string) (Credentials, error) {
 	return creds, err
 }
 
-// getCredentials dispatches to the IDC or Substrate credential path based on the
-// engineer's configured credential source (set via qt configure --use-identitycenter
-// or overridden per-session with USE_SUBSTRATE=true/false).
 func getCredentials(role RoleData) (Credentials, error) {
 	if useIDC() {
 		return getIDCCredentials(role)
@@ -113,8 +118,7 @@ func getCredentials(role RoleData) (Credentials, error) {
 
 func getIDCCredentials(role RoleData) (Credentials, error) {
 	if role == (RoleData{}) {
-		// No role specified: return Substrate account credentials (engineers expect 666642175330 as the default).
-		return getMetronomeSSORoleCredentials(staticSpecialAccounts["substrate"], "engineersreadonly")
+		return getMetronomeSSORoleCredentials(staticSpecialAccounts["substrate"], idcRoleReadOnly)
 	}
 
 	if role.SpecialAccount != "" {
@@ -134,16 +138,16 @@ func getIDCCredentials(role RoleData) (Credentials, error) {
 	return getIDCRoleCredentials(accountID, roleName, role.Role == "", fmt.Sprintf("%s-%s", role.Environment, role.Domain))
 }
 
-// getIDCRoleCredentials fetches IDC credentials, automatically falling back to
-// engineersreadonly if admin was the environment default and isn't available.
+// getIDCRoleCredentials fetches IDC credentials, falling back to idcRoleReadOnly
+// if admin was the environment default and isn't available.
 func getIDCRoleCredentials(accountID, roleName string, autoFallback bool, label string) (Credentials, error) {
 	creds, err := getMetronomeSSORoleCredentials(accountID, roleName)
 	if err == nil {
 		return creds, nil
 	}
-	if autoFallback && roleName == "admin" && errors.Is(err, errPermissionSetNotAvailable) {
-		log.Printf("[quikstrate] admin not available for %s, using engineersreadonly\n", label)
-		if creds, err = getMetronomeSSORoleCredentials(accountID, "engineersreadonly"); err == nil {
+	if autoFallback && roleName == idcRoleAdmin && errors.Is(err, errPermissionSetNotAvailable) {
+		log.Printf("[quikstrate] %s not available for %s, using %s\n", idcRoleAdmin, label, idcRoleReadOnly)
+		if creds, err = getMetronomeSSORoleCredentials(accountID, idcRoleReadOnly); err == nil {
 			return creds, nil
 		}
 	}
@@ -163,34 +167,26 @@ func getSubstrateCredentials(role RoleData) (Credentials, error) {
 	return substrateAssumeRole(role)
 }
 
-// idcRoleForEnvironment returns the default IAM Identity Center permission set name.
-// Staging defaults to admin (engineers deploy there); prod defaults to read-only.
 func idcRoleForEnvironment(environment string) string {
 	if environment == "staging" {
-		return "admin"
+		return idcRoleAdmin
 	}
-	return "engineersreadonly"
+	return idcRoleReadOnly
 }
 
 // normalizeIDCRole converts old Substrate role names to IDC permission set names,
 // and fills in the environment default when no role is specified.
-// This ensures existing scripts that pass --role Administrator keep working.
+// This ensures existing scripts that pass --role Administrator or Auditor keep working.
 func normalizeIDCRole(role, environment string) string {
 	switch role {
-	case "", "Auditor":
+	case "", substrateRoleReadOnly:
 		return idcRoleForEnvironment(environment)
-	case "Administrator":
-		return "admin"
+	case substrateRoleAdmin:
+		return idcRoleAdmin
 	default:
-		// Assume it's already an IDC permission set name (admin, engineersreadonly, etc.)
 		return role
 	}
 }
-
-// ---- Substrate fallback helpers ----
-//
-// These are used when Metronome IAM Identity Center is unavailable, typically
-// because the engineer hasn't joined sso-metronome-identitycenter yet.
 
 func substrateBaseCredentials() (Credentials, error) {
 	cmd := "substrate credentials --format json --force"
@@ -204,13 +200,11 @@ func substrateBaseCredentials() (Credentials, error) {
 }
 
 func substrateAssumeRole(role RoleData) (Credentials, error) {
-	// substrate assume-role requires base credentials in the environment.
 	baseCreds, err := substrateBaseCredentials()
 	if err != nil {
 		return Credentials{}, err
 	}
 	baseCreds.SetEnv()
-
 	subRole := substrateRoleName(role.Role, role.Environment)
 	cmd := fmt.Sprintf("substrate assume-role --environment %s --domain %s --quality %s --role %s --format json",
 		role.Environment, role.Domain, role.Quality, subRole)
@@ -224,13 +218,11 @@ func substrateAssumeRole(role RoleData) (Credentials, error) {
 }
 
 func substrateSpecialCredentials(name string) (Credentials, error) {
-	// substrate assume-role requires base credentials in the environment.
 	baseCreds, err := substrateBaseCredentials()
 	if err != nil {
 		return Credentials{}, err
 	}
 	baseCreds.SetEnv()
-
 	var cmd string
 	if name == "management" {
 		cmd = "substrate assume-role --management --format json"
@@ -250,21 +242,20 @@ func substrateSpecialCredentials(name string) (Credentials, error) {
 // equivalent Substrate role name for the fallback path.
 func substrateRoleName(role, environment string) string {
 	switch role {
-	case "admin", "Administrator":
-		return "Administrator"
-	case "engineersreadonly", "Auditor", "":
+	case idcRoleAdmin, substrateRoleAdmin:
+		return substrateRoleAdmin
+	case idcRoleReadOnly, substrateRoleReadOnly, "":
 		if environment == "staging" {
-			return "Administrator"
+			return substrateRoleAdmin
 		}
-		return "Auditor"
+		return substrateRoleReadOnly
 	default:
 		return role
 	}
 }
 
-// defaultCredsFile returns the cache path for base (no-role) credentials.
-// IDC and Substrate have separate files so switching sources via USE_SUBSTRATE
-// or config always fetches fresh credentials from the right provider.
+// defaultCredsFile returns separate cache paths for IDC vs Substrate so
+// switching sources always fetches fresh credentials.
 func defaultCredsFile() string {
 	if useIDC() {
 		return filepath.Join(CredsDir, "credentials-idc.json")

--- a/internal/creds/credentials.go
+++ b/internal/creds/credentials.go
@@ -16,8 +16,8 @@ import (
 const defaultRefreshTrigger = 5 * time.Minute
 
 const (
-	idcRoleAdmin    = "admin"
-	idcRoleReadOnly = "engineersreadonly"
+	idcRoleAdmin          = "admin"
+	idcRoleReadOnly       = "engineersreadonly"
 	substrateRoleAdmin    = "Administrator"
 	substrateRoleReadOnly = "Auditor"
 )
@@ -122,7 +122,7 @@ func getIDCCredentials(role RoleData) (Credentials, error) {
 	}
 
 	if role.SpecialAccount != "" {
-		roleName := normalizeIDCRole(role.Role, "prod")
+		roleName := normalizeIDCRole(role.Role)
 		accountID, err := lookupSpecialAccountID(role.SpecialAccount)
 		if err != nil {
 			return Credentials{}, err
@@ -134,7 +134,7 @@ func getIDCCredentials(role RoleData) (Credentials, error) {
 	if err != nil {
 		return Credentials{}, err
 	}
-	roleName := normalizeIDCRole(role.Role, role.Environment)
+	roleName := normalizeIDCRole(role.Role)
 	return getIDCRoleCredentials(accountID, roleName, fmt.Sprintf("%s-%s", role.Environment, role.Domain))
 }
 
@@ -159,20 +159,10 @@ func getSubstrateCredentials(role RoleData) (Credentials, error) {
 	return substrateAssumeRole(role)
 }
 
-func idcRoleForEnvironment(environment string) string {
-	if environment == "staging" {
-		return idcRoleAdmin
-	}
-	return idcRoleReadOnly
-}
-
-// normalizeIDCRole converts old Substrate role names to IDC permission set names,
-// and fills in the environment default when no role is specified.
+// normalizeIDCRole converts old Substrate role names to IDC permission set names.
 // This ensures existing scripts that pass --role Administrator or Auditor keep working.
-func normalizeIDCRole(role, environment string) string {
+func normalizeIDCRole(role string) string {
 	switch role {
-	case "":
-		return idcRoleForEnvironment(environment)
 	case substrateRoleReadOnly:
 		return idcRoleReadOnly
 	case substrateRoleAdmin:
@@ -199,9 +189,8 @@ func substrateAssumeRole(role RoleData) (Credentials, error) {
 		return Credentials{}, err
 	}
 	baseCreds.SetEnv()
-	subRole := substrateRoleName(role.Role, role.Environment)
 	cmd := fmt.Sprintf("substrate assume-role --environment %s --domain %s --quality %s --role %s --format json",
-		role.Environment, role.Domain, role.Quality, subRole)
+		role.Environment, role.Domain, role.Quality, role.Role)
 	log.Print("running: ", cmd)
 	byteValue, err := script.NewPipe().WithStderr(os.Stderr).Exec(cmd).Bytes()
 	if err != nil {
@@ -230,22 +219,6 @@ func substrateSpecialCredentials(name string) (Credentials, error) {
 	}
 	var creds Credentials
 	return creds, json.Unmarshal(byteValue, &creds)
-}
-
-// substrateRoleName translates an IDC permission set name (or empty string) to the
-// equivalent Substrate role name for the fallback path.
-func substrateRoleName(role, environment string) string {
-	switch role {
-	case idcRoleAdmin, substrateRoleAdmin:
-		return substrateRoleAdmin
-	case idcRoleReadOnly, substrateRoleReadOnly, "":
-		if environment == "staging" {
-			return substrateRoleAdmin
-		}
-		return substrateRoleReadOnly
-	default:
-		return role
-	}
 }
 
 // defaultCredsFile returns separate cache paths for IDC vs Substrate so

--- a/internal/creds/credentials.go
+++ b/internal/creds/credentials.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/bitfield/script"
@@ -84,14 +85,75 @@ func getCredsFromFile(file string) (Credentials, error) {
 
 func refreshCredentials(role RoleData, file string) (Credentials, error) {
 	creds, _ := getCredsFromFile(file)
-
 	if creds.needsRefresh() {
 		return getAndWriteCredentials(role, file)
 	}
 	return creds, nil
 }
 
+func getAndWriteCredentials(role RoleData, file string) (Credentials, error) {
+	creds, err := getCredentials(role)
+	if err != nil {
+		return Credentials{}, err
+	}
+	log.Printf("writing credentials to %s (expiring in %s)\n", file, creds.Expiration.Sub(time.Now()).Round(time.Minute).String())
+	creds.Write(file)
+	return creds, err
+}
+
+// getCredentials dispatches to the IDC or Substrate credential path based on the
+// engineer's configured credential source (set via qt configure --use-identitycenter
+// or overridden per-session with USE_SUBSTRATE=true/false).
 func getCredentials(role RoleData) (Credentials, error) {
+	if useIDC() {
+		return getIDCCredentials(role)
+	}
+	return getSubstrateCredentials(role)
+}
+
+func getIDCCredentials(role RoleData) (Credentials, error) {
+	if role == (RoleData{}) {
+		// No role specified: return Substrate account credentials (engineers expect 666642175330 as the default).
+		return getMetronomeSSORoleCredentials(staticSpecialAccounts["substrate"], "engineersreadonly")
+	}
+
+	if role.SpecialAccount != "" {
+		roleName := normalizeIDCRole(role.Role, "prod")
+		accountID, err := lookupSpecialAccountID(role.SpecialAccount)
+		if err != nil {
+			return Credentials{}, err
+		}
+		return getIDCRoleCredentials(accountID, roleName, role.Role == "", role.SpecialAccount)
+	}
+
+	accountID, err := lookupServiceAccountID(role.Domain, role.Environment)
+	if err != nil {
+		return Credentials{}, err
+	}
+	roleName := normalizeIDCRole(role.Role, role.Environment)
+	return getIDCRoleCredentials(accountID, roleName, role.Role == "", fmt.Sprintf("%s-%s", role.Environment, role.Domain))
+}
+
+// getIDCRoleCredentials fetches IDC credentials, automatically falling back to
+// engineersreadonly if admin was the environment default and isn't available.
+func getIDCRoleCredentials(accountID, roleName string, autoFallback bool, label string) (Credentials, error) {
+	creds, err := getMetronomeSSORoleCredentials(accountID, roleName)
+	if err == nil {
+		return creds, nil
+	}
+	if autoFallback && roleName == "admin" && errors.Is(err, errPermissionSetNotAvailable) {
+		log.Printf("[quikstrate] admin not available for %s, using engineersreadonly\n", label)
+		if creds, err = getMetronomeSSORoleCredentials(accountID, "engineersreadonly"); err == nil {
+			return creds, nil
+		}
+	}
+	if errors.Is(err, errPermissionSetNotAvailable) {
+		return Credentials{}, fmt.Errorf("no %q permission set for %s", roleName, label)
+	}
+	return Credentials{}, err
+}
+
+func getSubstrateCredentials(role RoleData) (Credentials, error) {
 	if role == (RoleData{}) {
 		return substrateBaseCredentials()
 	}
@@ -100,6 +162,35 @@ func getCredentials(role RoleData) (Credentials, error) {
 	}
 	return substrateAssumeRole(role)
 }
+
+// idcRoleForEnvironment returns the default IAM Identity Center permission set name.
+// Staging defaults to admin (engineers deploy there); prod defaults to read-only.
+func idcRoleForEnvironment(environment string) string {
+	if environment == "staging" {
+		return "admin"
+	}
+	return "engineersreadonly"
+}
+
+// normalizeIDCRole converts old Substrate role names to IDC permission set names,
+// and fills in the environment default when no role is specified.
+// This ensures existing scripts that pass --role Administrator keep working.
+func normalizeIDCRole(role, environment string) string {
+	switch role {
+	case "", "Auditor":
+		return idcRoleForEnvironment(environment)
+	case "Administrator":
+		return "admin"
+	default:
+		// Assume it's already an IDC permission set name (admin, engineersreadonly, etc.)
+		return role
+	}
+}
+
+// ---- Substrate fallback helpers ----
+//
+// These are used when Metronome IAM Identity Center is unavailable, typically
+// because the engineer hasn't joined sso-metronome-identitycenter yet.
 
 func substrateBaseCredentials() (Credentials, error) {
 	cmd := "substrate credentials --format json --force"
@@ -113,13 +204,16 @@ func substrateBaseCredentials() (Credentials, error) {
 }
 
 func substrateAssumeRole(role RoleData) (Credentials, error) {
-	baseCreds, err := getDefaultCredentials()
+	// substrate assume-role requires base credentials in the environment.
+	baseCreds, err := substrateBaseCredentials()
 	if err != nil {
 		return Credentials{}, err
 	}
 	baseCreds.SetEnv()
+
+	subRole := substrateRoleName(role.Role, role.Environment)
 	cmd := fmt.Sprintf("substrate assume-role --environment %s --domain %s --quality %s --role %s --format json",
-		role.Environment, role.Domain, role.Quality, role.Role)
+		role.Environment, role.Domain, role.Quality, subRole)
 	log.Print("running: ", cmd)
 	byteValue, err := script.NewPipe().WithStderr(os.Stderr).Exec(cmd).Bytes()
 	if err != nil {
@@ -130,11 +224,13 @@ func substrateAssumeRole(role RoleData) (Credentials, error) {
 }
 
 func substrateSpecialCredentials(name string) (Credentials, error) {
-	baseCreds, err := getDefaultCredentials()
+	// substrate assume-role requires base credentials in the environment.
+	baseCreds, err := substrateBaseCredentials()
 	if err != nil {
 		return Credentials{}, err
 	}
 	baseCreds.SetEnv()
+
 	var cmd string
 	if name == "management" {
 		cmd = "substrate assume-role --management --format json"
@@ -150,13 +246,32 @@ func substrateSpecialCredentials(name string) (Credentials, error) {
 	return creds, json.Unmarshal(byteValue, &creds)
 }
 
-func getAndWriteCredentials(role RoleData, file string) (Credentials, error) {
-	creds, err := getCredentials(role)
-	if err != nil {
-		return Credentials{}, err
+// substrateRoleName translates an IDC permission set name (or empty string) to the
+// equivalent Substrate role name for the fallback path.
+func substrateRoleName(role, environment string) string {
+	switch role {
+	case "admin", "Administrator":
+		return "Administrator"
+	case "engineersreadonly", "Auditor", "":
+		if environment == "staging" {
+			return "Administrator"
+		}
+		return "Auditor"
+	default:
+		return role
 	}
+}
 
-	log.Printf("writing credentials to %s (expiring in %s)\n", file, creds.Expiration.Sub(time.Now()).Round(time.Minute).String())
-	creds.Write(file)
-	return creds, err
+// defaultCredsFile returns the cache path for base (no-role) credentials.
+// IDC and Substrate have separate files so switching sources via USE_SUBSTRATE
+// or config always fetches fresh credentials from the right provider.
+func defaultCredsFile() string {
+	if useIDC() {
+		return filepath.Join(CredsDir, "credentials-idc.json")
+	}
+	return DefaultCredsFile
+}
+
+func getDefaultCredentials() (Credentials, error) {
+	return refreshCredentials(RoleData{}, defaultCredsFile())
 }

--- a/internal/creds/idc.go
+++ b/internal/creds/idc.go
@@ -1,0 +1,201 @@
+package creds
+
+import (
+	"context"
+	"crypto/sha1"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/sso"
+	"github.com/aws/aws-sdk-go-v2/service/sso/types"
+	smithy "github.com/aws/smithy-go"
+)
+
+// ssoToken mirrors the subset of fields the AWS CLI writes to ~/.aws/sso/cache/*.json.
+type ssoToken struct {
+	AccessToken string `json:"accessToken"`
+	ExpiresAt   string `json:"expiresAt"`
+}
+
+func (t ssoToken) expiry() (time.Time, error) {
+	// AWS CLI writes either RFC3339 "Z" suffix or a bare "UTC" suffix depending on version.
+	s := strings.TrimSuffix(t.ExpiresAt, "UTC")
+	if !strings.HasSuffix(s, "Z") {
+		s += "Z"
+	}
+	return time.Parse(time.RFC3339, s)
+}
+
+func (t ssoToken) isValid() bool {
+	exp, err := t.expiry()
+	if err != nil {
+		return false
+	}
+	return time.Now().Add(defaultRefreshTrigger).Before(exp)
+}
+
+// tokenCachePath returns the path the AWS CLI uses for a named sso-session token.
+// Filename is sha1(sessionName).json — the same hashing scheme the AWS CLI uses.
+func tokenCachePath(sessionName string) string {
+	h := sha1.New()
+	h.Write([]byte(sessionName))
+	return filepath.Join(home, ".aws", "sso", "cache", fmt.Sprintf("%x.json", h.Sum(nil)))
+}
+
+func readSSOToken(sessionName string) (ssoToken, error) {
+	data, err := os.ReadFile(tokenCachePath(sessionName))
+	if err != nil {
+		return ssoToken{}, err
+	}
+	var t ssoToken
+	return t, json.Unmarshal(data, &t)
+}
+
+// writeSSOSessionConfig writes a [sso-session <name>] block to ~/.aws/config.
+// Writes directly to the file rather than using `aws configure set` because
+// AWS CLI 2.x does not reliably handle the sso-session.* namespace in
+// `aws configure set` — it silently writes a garbage key under [default] instead.
+func writeSSOSessionConfig(sessionName, startURL, region string) error {
+	if configDryrun {
+		log.Printf("aws configure set sso-session.%s.sso_start_url %s", sessionName, startURL)
+		log.Printf("aws configure set sso-session.%s.sso_region %s", sessionName, region)
+		log.Printf("aws configure set sso-session.%s.sso_registration_scopes sso:account:access", sessionName)
+		return nil
+	}
+
+	block := fmt.Sprintf("[sso-session %s]\nsso_start_url = %s\nsso_region = %s\nsso_registration_scopes = sso:account:access\n\n",
+		sessionName, startURL, region)
+
+	existing, err := os.ReadFile(awsConfigFile)
+	if os.IsNotExist(err) {
+		return os.WriteFile(awsConfigFile, []byte(block), 0600)
+	}
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", awsConfigFile, err)
+	}
+
+	content := removeSSOSession(string(existing), sessionName) + block
+	return os.WriteFile(awsConfigFile, []byte(content), 0600)
+}
+
+// removeSSOSession strips an existing [sso-session name] block from an AWS
+// config file's contents so writeSSOSessionConfig can append a fresh one.
+func removeSSOSession(content, sessionName string) string {
+	header := "[sso-session " + sessionName + "]"
+	var out strings.Builder
+	skip := false
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == header {
+			skip = true
+			continue
+		}
+		if skip && strings.HasPrefix(trimmed, "[") {
+			skip = false
+		}
+		if !skip {
+			out.WriteString(line + "\n")
+		}
+	}
+	return out.String()
+}
+
+// getSSOToken returns a valid token for the given session, triggering an
+// interactive browser login if the cached token is missing or expired.
+func getSSOToken(sessionName, startURL, region string) (ssoToken, error) {
+	token, err := readSSOToken(sessionName)
+	if err == nil && token.isValid() {
+		return token, nil
+	}
+	if err := writeSSOSessionConfig(sessionName, startURL, region); err != nil {
+		return ssoToken{}, err
+	}
+	cmd := exec.Command("aws", "sso", "login", "--sso-session", sessionName)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stderr // must use stderr so login prompts don't pollute eval $() captures
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return ssoToken{}, fmt.Errorf("aws sso login --sso-session %s: %w", sessionName, err)
+	}
+	token, err = readSSOToken(sessionName)
+	if err != nil {
+		return ssoToken{}, fmt.Errorf("reading SSO token after login: %w", err)
+	}
+	return token, nil
+}
+
+// errPermissionSetNotAvailable is returned when the engineer lacks a specific IDC permission
+// set, as opposed to IDC being generally unavailable (network error, expired token, etc.).
+// Callers can use errors.Is to distinguish and retry with a lower-privilege role.
+var errPermissionSetNotAvailable = errors.New("permission set not available")
+
+// isPermissionDenied returns true for unmodeled 403 ForbiddenException responses from the
+// SSO API, which the SDK doesn't map to a typed error but surfaces as a smithy.APIError.
+func isPermissionDenied(err error) bool {
+	var apiErr smithy.APIError
+	return errors.As(err, &apiErr) && apiErr.ErrorCode() == "ForbiddenException"
+}
+
+// getSSORoleCredentials exchanges an SSO access token for short-lived IAM credentials
+// for the given account and permission set. Caching is handled by the caller.
+func getSSORoleCredentials(sessionName, startURL, region, accountID, roleName string) (Credentials, error) {
+	token, err := getSSOToken(sessionName, startURL, region)
+	if err != nil {
+		return Credentials{}, err
+	}
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(), awsconfig.WithRegion(region))
+	if err != nil {
+		return Credentials{}, err
+	}
+
+	resp, err := sso.NewFromConfig(cfg).GetRoleCredentials(context.Background(), &sso.GetRoleCredentialsInput{
+		AccountId:   aws.String(accountID),
+		RoleName:    aws.String(roleName),
+		AccessToken: aws.String(token.AccessToken),
+	})
+	if err != nil {
+		// Distinguish "you don't have this permission set" from other errors so the
+		// message points the engineer at LMS rather than showing a raw AWS error.
+		var unauthorized *types.UnauthorizedException
+		var notFound *types.ResourceNotFoundException
+		if errors.As(err, &unauthorized) || errors.As(err, &notFound) || isPermissionDenied(err) {
+			return Credentials{}, fmt.Errorf("%w: no %q permission set for account %s", errPermissionSetNotAvailable, roleName, accountID)
+		}
+		return Credentials{}, fmt.Errorf("GetRoleCredentials: %w", err)
+	}
+
+	return Credentials{
+		AccessKeyId:     aws.ToString(resp.RoleCredentials.AccessKeyId),
+		SecretAccessKey: aws.ToString(resp.RoleCredentials.SecretAccessKey),
+		SessionToken:    aws.ToString(resp.RoleCredentials.SessionToken),
+		Expiration:      time.UnixMilli(resp.RoleCredentials.Expiration),
+		Version:         1,
+	}, nil
+}
+
+// ---- Metronome IAM Identity Center ----
+//
+// Primary credential source. Engineers authenticate via Shibboleth (Stripe SSO)
+// at https://d-9267463e84.awsapps.com/start, gated by the sso-metronome-identitycenter LMS permission.
+// This instance will be deprecated when Metronome accounts migrate to the Stripe AWS org (Oct 2026).
+
+const (
+	metronomeIDCStartURL    = "https://d-9267463e84.awsapps.com/start"
+	metronomeIDCRegion      = "us-west-2"
+	metronomeIDCSessionName = "metronome"
+)
+
+func getMetronomeSSORoleCredentials(accountID, roleName string) (Credentials, error) {
+	return getSSORoleCredentials(metronomeIDCSessionName, metronomeIDCStartURL, metronomeIDCRegion, accountID, roleName)
+}
+

--- a/internal/creds/idc.go
+++ b/internal/creds/idc.go
@@ -43,8 +43,8 @@ func (t ssoToken) isValid() bool {
 	return time.Now().Add(defaultRefreshTrigger).Before(exp)
 }
 
-// tokenCachePath returns the path the AWS CLI uses for a named sso-session token.
-// Filename is sha1(sessionName).json — the same hashing scheme the AWS CLI uses.
+// tokenCachePath returns the AWS CLI's cache path for a named sso-session token:
+// sha1(sessionName).json.
 func tokenCachePath(sessionName string) string {
 	h := sha1.New()
 	h.Write([]byte(sessionName))
@@ -60,20 +60,16 @@ func readSSOToken(sessionName string) (ssoToken, error) {
 	return t, json.Unmarshal(data, &t)
 }
 
-// writeSSOSessionConfig writes a [sso-session <name>] block to ~/.aws/config.
-// Writes directly to the file rather than using `aws configure set` because
-// AWS CLI 2.x does not reliably handle the sso-session.* namespace in
-// `aws configure set` — it silently writes a garbage key under [default] instead.
+// writeSSOSessionConfig writes a [sso-session metronome] block to ~/.aws/config directly,
+// `aws configure set` mishandles the sso-session.* namespace
 func writeSSOSessionConfig(sessionName, startURL, region string) error {
-	if configDryrun {
-		log.Printf("aws configure set sso-session.%s.sso_start_url %s", sessionName, startURL)
-		log.Printf("aws configure set sso-session.%s.sso_region %s", sessionName, region)
-		log.Printf("aws configure set sso-session.%s.sso_registration_scopes sso:account:access", sessionName)
-		return nil
-	}
-
 	block := fmt.Sprintf("[sso-session %s]\nsso_start_url = %s\nsso_region = %s\nsso_registration_scopes = sso:account:access\n\n",
 		sessionName, startURL, region)
+
+	if configDryrun {
+		log.Printf("would write to %s:\n%s", awsConfigFile, block)
+		return nil
+	}
 
 	existing, err := os.ReadFile(awsConfigFile)
 	if os.IsNotExist(err) {
@@ -87,8 +83,8 @@ func writeSSOSessionConfig(sessionName, startURL, region string) error {
 	return os.WriteFile(awsConfigFile, []byte(content), 0600)
 }
 
-// removeSSOSession strips an existing [sso-session name] block from an AWS
-// config file's contents so writeSSOSessionConfig can append a fresh one.
+// removeSSOSession strips the [sso-session metronome] block so writeSSOSessionConfig
+// can append a fresh one.
 func removeSSOSession(content, sessionName string) string {
 	header := "[sso-session " + sessionName + "]"
 	var out strings.Builder
@@ -133,26 +129,34 @@ func getSSOToken(sessionName, startURL, region string) (ssoToken, error) {
 	return token, nil
 }
 
-// errPermissionSetNotAvailable is returned when the engineer lacks a specific IDC permission
-// set, as opposed to IDC being generally unavailable (network error, expired token, etc.).
-// Callers can use errors.Is to distinguish and retry with a lower-privilege role.
 var errPermissionSetNotAvailable = errors.New("permission set not available")
 
-// isPermissionDenied returns true for unmodeled 403 ForbiddenException responses from the
-// SSO API, which the SDK doesn't map to a typed error but surfaces as a smithy.APIError.
-func isPermissionDenied(err error) bool {
+func isUnmodeledForbidden(err error) bool {
 	var apiErr smithy.APIError
 	return errors.As(err, &apiErr) && apiErr.ErrorCode() == "ForbiddenException"
 }
 
 // getSSORoleCredentials exchanges an SSO access token for short-lived IAM credentials
-// for the given account and permission set. Caching is handled by the caller.
 func getSSORoleCredentials(sessionName, startURL, region, accountID, roleName string) (Credentials, error) {
 	token, err := getSSOToken(sessionName, startURL, region)
 	if err != nil {
 		return Credentials{}, err
 	}
 
+	creds, err := exchangeSSOToken(region, accountID, roleName, token)
+	if err == nil {
+		return creds, nil
+	}
+
+	var unauthorized *types.UnauthorizedException
+	var notFound *types.ResourceNotFoundException
+	if errors.As(err, &unauthorized) || errors.As(err, &notFound) || isUnmodeledForbidden(err) {
+		return Credentials{}, fmt.Errorf("%w: no %q permission set for account %s", errPermissionSetNotAvailable, roleName, accountID)
+	}
+	return Credentials{}, fmt.Errorf("GetRoleCredentials: %w", err)
+}
+
+func exchangeSSOToken(region, accountID, roleName string, token ssoToken) (Credentials, error) {
 	cfg, err := awsconfig.LoadDefaultConfig(context.Background(), awsconfig.WithRegion(region))
 	if err != nil {
 		return Credentials{}, err
@@ -164,14 +168,7 @@ func getSSORoleCredentials(sessionName, startURL, region, accountID, roleName st
 		AccessToken: aws.String(token.AccessToken),
 	})
 	if err != nil {
-		// Distinguish "you don't have this permission set" from other errors so the
-		// message points the engineer at LMS rather than showing a raw AWS error.
-		var unauthorized *types.UnauthorizedException
-		var notFound *types.ResourceNotFoundException
-		if errors.As(err, &unauthorized) || errors.As(err, &notFound) || isPermissionDenied(err) {
-			return Credentials{}, fmt.Errorf("%w: no %q permission set for account %s", errPermissionSetNotAvailable, roleName, accountID)
-		}
-		return Credentials{}, fmt.Errorf("GetRoleCredentials: %w", err)
+		return Credentials{}, err
 	}
 
 	return Credentials{
@@ -184,11 +181,9 @@ func getSSORoleCredentials(sessionName, startURL, region, accountID, roleName st
 }
 
 // ---- Metronome IAM Identity Center ----
-//
-// Primary credential source. Engineers authenticate via Shibboleth (Stripe SSO)
-// at https://d-9267463e84.awsapps.com/start, gated by the https://go/ldapg/access-metronome-aws-admin LMS permission.
-// This instance will be deprecated when Metronome accounts migrate to the Stripe AWS org (Oct 2026).
-
+// Opt-in credential source
+// Gated by the https://go/ldapg/access-metronome-aws-admin
+// This instance is retired when Metronome accounts migrate to the Stripe AWS org
 const (
 	metronomeIDCStartURL    = "https://d-9267463e84.awsapps.com/start"
 	metronomeIDCRegion      = "us-west-2"

--- a/internal/creds/idc.go
+++ b/internal/creds/idc.go
@@ -186,7 +186,7 @@ func getSSORoleCredentials(sessionName, startURL, region, accountID, roleName st
 // ---- Metronome IAM Identity Center ----
 //
 // Primary credential source. Engineers authenticate via Shibboleth (Stripe SSO)
-// at https://d-9267463e84.awsapps.com/start, gated by the sso-metronome-identitycenter LMS permission.
+// at https://d-9267463e84.awsapps.com/start, gated by the https://go/ldapg/access-metronome-aws-admin LMS permission.
 // This instance will be deprecated when Metronome accounts migrate to the Stripe AWS org (Oct 2026).
 
 const (
@@ -198,4 +198,3 @@ const (
 func getMetronomeSSORoleCredentials(accountID, roleName string) (Credentials, error) {
 	return getSSORoleCredentials(metronomeIDCSessionName, metronomeIDCStartURL, metronomeIDCRegion, accountID, roleName)
 }
-

--- a/internal/creds/utils.go
+++ b/internal/creds/utils.go
@@ -80,13 +80,15 @@ func (r RoleData) GetFilename() string {
 	}
 	if r.SpecialAccount != "" {
 		role := r.Role
-		if role == "" {
-			role = idcRoleReadOnly
+		if useIDC() {
+			role = normalizeIDCRole(r.Role, "prod")
 		}
 		return filepath.Join(CredsDir, fmt.Sprintf("special-%s-%s%s", r.SpecialAccount, role, suffix))
 	}
 	role := r.Role
-	if role == "" {
+	if useIDC() {
+		role = normalizeIDCRole(r.Role, r.Environment)
+	} else if role == "" {
 		role = idcRoleForEnvironment(r.Environment)
 	}
 	return filepath.Join(CredsDir, strings.ToLower(fmt.Sprintf("%s-%s-%s-%s%s", r.Environment, r.Domain, r.Quality, role, suffix)))

--- a/internal/creds/utils.go
+++ b/internal/creds/utils.go
@@ -21,16 +21,16 @@ var (
 			Name:           "staging",
 			Aliases:        []string{"staging", "stg"},
 			DefaultQuality: "alpha",
-			DefaultRole:    "admin",
+			DefaultRole:    "Administrator",
 		},
 		"prod": {
 			Name:           "prod",
 			Aliases:        []string{"production", "prod", "prd"},
 			DefaultQuality: "gamma",
-			DefaultRole:    "engineersreadonly",
+			DefaultRole:    "Auditor",
 		},
 	}
-	Domains  = []string{"api", "auth", "druid", "graphql", "ingest", "integrations", "lakehouse", "lambda", "marketplaces", "network-staging", "notifications", "static-sites", "internal-services"}
+	Domains = []string{"api", "auth", "druid", "graphql", "ingest", "integrations", "lakehouse", "lambda", "marketplaces", "network-staging", "notifications", "static-sites", "internal-services"}
 	Clusters = []ClusterSpec{
 		{
 			Name:   "graphql",
@@ -81,7 +81,7 @@ func (r RoleData) GetFilename() string {
 	if r.SpecialAccount != "" {
 		role := r.Role
 		if role == "" {
-			role = "engineersreadonly"
+			role = idcRoleReadOnly
 		}
 		return filepath.Join(CredsDir, fmt.Sprintf("special-%s-%s%s", r.SpecialAccount, role, suffix))
 	}

--- a/internal/creds/utils.go
+++ b/internal/creds/utils.go
@@ -81,15 +81,13 @@ func (r RoleData) GetFilename() string {
 	if r.SpecialAccount != "" {
 		role := r.Role
 		if useIDC() {
-			role = normalizeIDCRole(r.Role, "prod")
+			role = normalizeIDCRole(r.Role)
 		}
 		return filepath.Join(CredsDir, fmt.Sprintf("special-%s-%s%s", r.SpecialAccount, role, suffix))
 	}
 	role := r.Role
 	if useIDC() {
-		role = normalizeIDCRole(r.Role, r.Environment)
-	} else if role == "" {
-		role = idcRoleForEnvironment(r.Environment)
+		role = normalizeIDCRole(r.Role)
 	}
 	return filepath.Join(CredsDir, strings.ToLower(fmt.Sprintf("%s-%s-%s-%s%s", r.Environment, r.Domain, r.Quality, role, suffix)))
 }

--- a/internal/creds/utils.go
+++ b/internal/creds/utils.go
@@ -21,16 +21,16 @@ var (
 			Name:           "staging",
 			Aliases:        []string{"staging", "stg"},
 			DefaultQuality: "alpha",
-			DefaultRole:    "Administrator",
+			DefaultRole:    "admin",
 		},
 		"prod": {
 			Name:           "prod",
 			Aliases:        []string{"production", "prod", "prd"},
 			DefaultQuality: "gamma",
-			DefaultRole:    "Auditor",
+			DefaultRole:    "engineersreadonly",
 		},
 	}
-	Domains = []string{"api", "auth", "druid", "graphql", "ingest", "integrations", "lakehouse", "lambda", "marketplaces", "network-staging", "notifications", "static-sites", "internal-services"}
+	Domains  = []string{"api", "auth", "druid", "graphql", "ingest", "integrations", "lakehouse", "lambda", "marketplaces", "network-staging", "notifications", "static-sites", "internal-services"}
 	Clusters = []ClusterSpec{
 		{
 			Name:   "graphql",
@@ -74,14 +74,22 @@ type RoleData struct {
 }
 
 func (r RoleData) GetFilename() string {
+	suffix := ".json"
+	if useIDC() {
+		suffix = "-idc.json"
+	}
 	if r.SpecialAccount != "" {
 		role := r.Role
 		if role == "" {
-			role = "default"
+			role = "engineersreadonly"
 		}
-		return filepath.Join(CredsDir, fmt.Sprintf("special-%s-%s.json", r.SpecialAccount, role))
+		return filepath.Join(CredsDir, fmt.Sprintf("special-%s-%s%s", r.SpecialAccount, role, suffix))
 	}
-	return filepath.Join(CredsDir, strings.ToLower(fmt.Sprintf("%s-%s-%s-%s.json", r.Environment, r.Domain, r.Quality, r.Role)))
+	role := r.Role
+	if role == "" {
+		role = idcRoleForEnvironment(r.Environment)
+	}
+	return filepath.Join(CredsDir, strings.ToLower(fmt.Sprintf("%s-%s-%s-%s%s", r.Environment, r.Domain, r.Quality, role, suffix)))
 }
 
 func ensureAWSEnvSet() {

--- a/scripts/identitycenter_test.sh
+++ b/scripts/identitycenter_test.sh
@@ -1,0 +1,436 @@
+#!/usr/bin/env bash
+# Test suite for the Metronome IDC credential source feature.
+#
+# Covers:
+#   1. Substrate path is unaffected when IDC is not configured.
+#   2. configure --use-identitycenter routes all commands through IDC.
+#   3. USE_SUBSTRATE=true forces Substrate even when IDC is configured.
+#   4. configure --use-substrate reverts to Substrate.
+#
+# Usage:
+#   ./scripts/identitycenter_test.sh [--engineersreadonly] [--run-configure]
+#
+#   Requires: access-metronome-aws-admin LMS permission
+#   --engineersreadonly  Use -r engineersreadonly for all assume commands (for testing
+#                        before admin permission sets are provisioned).
+#   --run-configure      Write real ~/.aws/config and ~/.kube/config during configure tests.
+
+set -euo pipefail
+
+# ── flags ────────────────────────────────────────────────────────────────────
+RUN_CONFIGURE=false
+ENGINEERSREADONLY=false
+for arg in "$@"; do
+  case "$arg" in
+    --engineersreadonly) ENGINEERSREADONLY=true ;;
+    --run-configure)     RUN_CONFIGURE=true ;;
+    *) echo "Unknown flag: $arg"; exit 1 ;;
+  esac
+done
+
+ROLE_FLAG=""
+[[ "$ENGINEERSREADONLY" == "true" ]] && ROLE_FLAG="-r engineersreadonly"
+
+# ── harness ──────────────────────────────────────────────────────────────────
+PASS=0; FAIL=0; SKIP=0
+FAILURES=()
+
+pass() { echo "  PASS  $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL  $1"; FAIL=$((FAIL + 1)); FAILURES+=("$1"); }
+skip() { echo "  SKIP  $1"; SKIP=$((SKIP + 1)); }
+
+assert_ok() {
+  local desc="$1"; shift
+  local out
+  if out=$("$@" 2>&1); then
+    pass "$desc"
+  else
+    fail "$desc — exit $? — $(echo "$out" | head -2)"
+  fi
+}
+
+assert_fail() {
+  local desc="$1"; shift
+  if "$@" > /dev/null 2>&1; then
+    fail "$desc — expected non-zero but got 0"
+  else
+    pass "$desc"
+  fi
+}
+
+assert_output() {
+  local desc="$1" pattern="$2"; shift 2
+  local out
+  out=$("$@" 2>&1)
+  local code=$?
+  if [[ $code -ne 0 ]]; then
+    fail "$desc — exit $code"
+  elif echo "$out" | rg -q "$pattern"; then
+    pass "$desc"
+  else
+    fail "$desc — pattern '$pattern' not found in: $(echo "$out" | head -2)"
+  fi
+}
+
+assert_json() {
+  local desc="$1"; shift
+  local out
+  out=$("$@" 2>&1)
+  local code=$?
+  if [[ $code -ne 0 ]]; then
+    fail "$desc — exit $code"
+  elif echo "$out" | python3 -m json.tool > /dev/null 2>&1; then
+    pass "$desc"
+  else
+    fail "$desc — not valid JSON: $(echo "$out" | head -2)"
+  fi
+}
+
+# Extract a top-level field from a JSON string passed on stdin
+json_field() { python3 -c "import sys,json; print(json.load(sys.stdin).get('$1',''))"; }
+
+# Print the AWS account ID that a JSON credentials blob resolves to.
+aws_account_for_creds() {
+  local json="$1"
+  local key secret token
+  key=$(echo "$json"    | json_field AccessKeyId)
+  secret=$(echo "$json" | json_field SecretAccessKey)
+  token=$(echo "$json"  | json_field SessionToken)
+  AWS_ACCESS_KEY_ID="$key" AWS_SECRET_ACCESS_KEY="$secret" AWS_SESSION_TOKEN="$token" \
+    aws sts get-caller-identity --query Account --output text 2>/dev/null
+}
+
+# Remove all IDC credential cache files so tests don't reuse stale credentials.
+idc_clear_creds() {
+  rm -f ~/.quikstrate/credentials-idc.json
+  rm -f ~/.quikstrate/*-idc.json 2>/dev/null || true
+}
+
+section() { echo; echo "── $1 ──────────────────────────────────────────────"; }
+
+# ── account fixtures ──────────────────────────────────────────────────────────
+declare -A SERVICE_ACCOUNTS=(
+  ["staging-api"]="407752757973"
+  ["staging-graphql"]="008444403661"
+  ["prod-api"]="477056945755"
+  ["prod-graphql"]="051318803586"
+  ["prod-internal-services"]="207567762512"
+)
+declare -A SPECIAL_ACCOUNTS=(
+  ["management"]="420073272039"
+  ["audit"]="465454680116"
+  ["deploy"]="703712742941"
+  ["network"]="814412579886"
+)
+
+CRED_FIELDS=(Version AccessKeyId SecretAccessKey SessionToken)
+
+# ── prerequisites ─────────────────────────────────────────────────────────────
+section "Prerequisites"
+
+BIN="${QUIKSTRATE_BIN:-quikstrate}"
+if ! command -v "$BIN" > /dev/null 2>&1; then
+  echo "ERROR: '$BIN' not found in PATH."
+  echo "       Build: go build -o quikstrate . && export PATH=\$PWD:\$PATH"
+  echo "       Or:    export QUIKSTRATE_BIN=/path/to/binary"
+  exit 1
+fi
+echo "  binary: $(command -v "$BIN")"
+
+if ! aws sts get-caller-identity > /dev/null 2>&1; then
+  echo "ERROR: No working AWS credentials. Source credentials before running."
+  exit 1
+fi
+echo "  AWS identity: $(aws sts get-caller-identity --query Arn --output text)"
+
+echo "  IDC: login will be triggered automatically on first credential fetch if needed"
+
+# Save the original config so it can be restored on exit regardless of outcome.
+SAVED_CONFIG=""
+if [[ -f ~/.quikstrate/config.json ]]; then
+  SAVED_CONFIG=$(cat ~/.quikstrate/config.json)
+fi
+
+restore_config() {
+  if [[ -n "$SAVED_CONFIG" ]]; then
+    echo "$SAVED_CONFIG" > ~/.quikstrate/config.json
+  else
+    rm -f ~/.quikstrate/config.json
+  fi
+}
+trap restore_config EXIT
+
+# ── Section 1: Substrate path (default, no IDC config) ───────────────────────
+
+section "Substrate: default (no IDC config)"
+
+rm -f ~/.quikstrate/config.json
+"$BIN" credentials --force --format json > /dev/null 2>&1
+
+assert_ok "Substrate: credentials.json written" \
+  test -f ~/.quikstrate/credentials.json
+
+if [[ -f ~/.quikstrate/credentials-idc.json ]]; then
+  substrate_mtime=$(stat -f %m ~/.quikstrate/credentials.json  2>/dev/null || stat -c %Y ~/.quikstrate/credentials.json  2>/dev/null)
+  idc_mtime=$(stat -f %m ~/.quikstrate/credentials-idc.json 2>/dev/null || stat -c %Y ~/.quikstrate/credentials-idc.json 2>/dev/null)
+  if [[ "$idc_mtime" -ge "$substrate_mtime" ]]; then
+    fail "Substrate: credentials-idc.json was freshly written (should not be)"
+  else
+    pass "Substrate: credentials-idc.json not freshly written"
+  fi
+else
+  pass "Substrate: credentials-idc.json does not exist"
+fi
+
+# ── Section 2: configure --use-identitycenter ────────────────────────────────
+
+section "IDC: configure --use-identitycenter"
+
+AWS_CONFIG_BEFORE=$(md5sum ~/.aws/config 2>/dev/null || true)
+"$BIN" configure --use-identitycenter --dryrun > /dev/null 2>&1
+[[ ! -f ~/.quikstrate/config.json ]] \
+  && pass "IDC: configure --dryrun did not create config.json" \
+  || fail "IDC: configure --dryrun created config.json"
+AWS_CONFIG_AFTER=$(md5sum ~/.aws/config 2>/dev/null || true)
+[[ "$AWS_CONFIG_BEFORE" == "$AWS_CONFIG_AFTER" ]] \
+  && pass "IDC: configure --dryrun did not modify ~/.aws/config" \
+  || fail "IDC: configure --dryrun modified ~/.aws/config"
+
+if [[ "$RUN_CONFIGURE" == "true" ]]; then
+  "$BIN" configure --use-identitycenter > /dev/null 2>&1
+else
+  mkdir -p ~/.quikstrate
+  echo '{"credential_source":"identitycenter"}' > ~/.quikstrate/config.json
+  echo
+  echo "  INFO  Pass --run-configure to write ~/.aws/config and test AWS_PROFILE end-to-end."
+fi
+
+if [[ -f ~/.quikstrate/config.json ]]; then
+  cfg_source=$(python3 -c "import json; print(json.load(open('$HOME/.quikstrate/config.json')).get('credential_source',''))")
+  [[ "$cfg_source" == "identitycenter" ]] \
+    && pass "IDC: config.json has credential_source=identitycenter" \
+    || fail "IDC: config.json has unexpected credential_source=$cfg_source"
+else
+  fail "IDC: config.json not written by configure --use-identitycenter"
+fi
+
+if [[ "$RUN_CONFIGURE" == "true" ]]; then
+  python3 -c "
+import sys
+data = open('$HOME/.aws/config').read()
+sys.exit(0 if '[sso-session metronome]' in data else 1)
+" 2>/dev/null \
+    && pass "IDC: [sso-session metronome] block in ~/.aws/config" \
+    || fail "IDC: [sso-session metronome] block missing from ~/.aws/config"
+
+  "$BIN" configure --use-identitycenter > /dev/null 2>&1 || true
+  block_count=$(python3 -c "print(open('$HOME/.aws/config').read().count('[sso-session metronome]'))")
+  [[ "$block_count" == "1" ]] \
+    && pass "IDC: configure --use-identitycenter is idempotent (1 sso-session block)" \
+    || fail "IDC: configure --use-identitycenter produced $block_count sso-session blocks"
+else
+  skip "IDC: sso-session block check (pass --run-configure)"
+  skip "IDC: configure idempotency check (pass --run-configure)"
+fi
+
+# ── Section 3: IDC credentials ───────────────────────────────────────────────
+
+section "IDC: cache isolation"
+
+SUBSTRATE_MTIME_BEFORE=$(stat -f %m ~/.quikstrate/credentials.json 2>/dev/null \
+  || stat -c %Y ~/.quikstrate/credentials.json 2>/dev/null || echo 0)
+
+idc_clear_creds
+"$BIN" credentials --force --format json > /dev/null 2>&1
+
+assert_ok "IDC: credentials-idc.json written after --force" \
+  test -f ~/.quikstrate/credentials-idc.json
+
+SUBSTRATE_MTIME_AFTER=$(stat -f %m ~/.quikstrate/credentials.json 2>/dev/null \
+  || stat -c %Y ~/.quikstrate/credentials.json 2>/dev/null || echo 0)
+if [[ "$SUBSTRATE_MTIME_AFTER" == "$SUBSTRATE_MTIME_BEFORE" ]]; then
+  pass "IDC: credentials.json not modified by IDC fetch"
+else
+  fail "IDC: credentials.json was modified during IDC fetch"
+fi
+
+section "IDC: base credentials"
+
+idc_clear_creds
+IDC_CREDS=$("$BIN" credentials --format json 2>/dev/null)
+
+if echo "$IDC_CREDS" | python3 -m json.tool > /dev/null 2>&1; then
+  pass "IDC: credentials --format json is valid JSON"
+else
+  fail "IDC: credentials --format json is not valid JSON"
+fi
+for field in "${CRED_FIELDS[@]}"; do
+  val=$(echo "$IDC_CREDS" | json_field "$field")
+  [[ -n "$val" ]] && pass "IDC: credentials has $field" || fail "IDC: credentials missing $field"
+done
+
+IDC_KEY=$(echo "$IDC_CREDS" | json_field AccessKeyId)
+IDC_SECRET=$(echo "$IDC_CREDS" | json_field SecretAccessKey)
+IDC_TOKEN=$(echo "$IDC_CREDS" | json_field SessionToken)
+assert_ok "IDC: credentials work (sts get-caller-identity)" \
+  env AWS_ACCESS_KEY_ID="$IDC_KEY" AWS_SECRET_ACCESS_KEY="$IDC_SECRET" AWS_SESSION_TOKEN="$IDC_TOKEN" \
+  aws sts get-caller-identity
+
+assert_ok "IDC: credentials --check exits 0 after fresh fetch" \
+  "$BIN" credentials --check
+
+section "IDC: assume"
+
+for key in "${!SERVICE_ACCOUNTS[@]}"; do
+  acct_env="${key%%-*}"
+  acct_domain="${key#*-}"
+  expected="${SERVICE_ACCOUNTS[$key]}"
+  prefix="IDC: assume $acct_env/$acct_domain"
+
+  rm -f ~/.quikstrate/"${acct_env}-${acct_domain}"-*-idc.json 2>/dev/null || true
+
+  json=$("$BIN" assume -e "$acct_env" -d "$acct_domain" $ROLE_FLAG --format json 2>/dev/null) || {
+    fail "$prefix — command failed"; continue
+  }
+  echo "$json" | python3 -m json.tool > /dev/null 2>&1 || { fail "$prefix — invalid JSON"; continue; }
+
+  actual=$(aws_account_for_creds "$json") || { fail "$prefix — sts failed"; continue; }
+  if [[ "$actual" == "$expected" ]]; then
+    pass "$prefix — correct account ($actual)"
+  else
+    fail "$prefix — wrong account: got $actual, expected $expected"
+  fi
+
+  idc_files=$(ls ~/.quikstrate/"${acct_env}-${acct_domain}"-*-idc.json 2>/dev/null || true)
+  [[ -n "$idc_files" ]] \
+    && pass "$prefix — cache file has -idc.json suffix" \
+    || fail "$prefix — no -idc.json cache file written"
+
+  plain_files=$(ls ~/.quikstrate/"${acct_env}-${acct_domain}"-*.json 2>/dev/null \
+    | rg -v '\-idc\.json' || true)
+  [[ -z "$plain_files" ]] \
+    && pass "$prefix — Substrate cache file not written" \
+    || fail "$prefix — unexpectedly wrote Substrate cache: $plain_files"
+done
+
+assert_fail "IDC: assume staging/internal-services exits non-zero" \
+  "$BIN" assume -e staging -d internal-services
+
+section "IDC: role normalization"
+
+if [[ "$ENGINEERSREADONLY" == "true" ]]; then
+  skip "IDC: --role Administrator normalizes to admin (pass without --engineersreadonly)"
+else
+  norm_json=$("$BIN" assume -e staging -d api --role Administrator --format json 2>/dev/null) || true
+  if echo "$norm_json" | python3 -m json.tool > /dev/null 2>&1; then
+    norm_acct=$(aws_account_for_creds "$norm_json")
+    [[ "$norm_acct" == "407752757973" ]] \
+      && pass "IDC: --role Administrator normalizes to admin (407752757973)" \
+      || fail "IDC: --role Administrator — wrong account $norm_acct"
+  else
+    fail "IDC: --role Administrator returned invalid JSON"
+  fi
+fi
+
+aud_json=$("$BIN" assume -e prod -d api --role Auditor --format json 2>/dev/null) || true
+if echo "$aud_json" | python3 -m json.tool > /dev/null 2>&1; then
+  aud_acct=$(aws_account_for_creds "$aud_json")
+  [[ "$aud_acct" == "477056945755" ]] \
+    && pass "IDC: --role Auditor normalizes to engineersreadonly (477056945755)" \
+    || fail "IDC: --role Auditor — wrong account $aud_acct"
+else
+  fail "IDC: --role Auditor returned invalid JSON"
+fi
+
+section "IDC: special accounts"
+
+for name in "${!SPECIAL_ACCOUNTS[@]}"; do
+  expected="${SPECIAL_ACCOUNTS[$name]}"
+  spec_json=$("$BIN" assume --special "$name" $ROLE_FLAG --format json 2>/dev/null) || {
+    fail "IDC: assume --special $name — command failed"; continue
+  }
+  actual=$(aws_account_for_creds "$spec_json") || {
+    fail "IDC: assume --special $name — sts failed"; continue
+  }
+  [[ "$actual" == "$expected" ]] \
+    && pass "IDC: assume --special $name — correct account ($actual)" \
+    || fail "IDC: assume --special $name — wrong account: got $actual, expected $expected"
+done
+
+section "IDC: accounts and whoami"
+
+assert_ok   "IDC: accounts --format text exits 0" "$BIN" accounts --format text
+assert_json "IDC: accounts --format json is valid JSON" "$BIN" accounts --format json
+assert_output "IDC: accounts --format json has Accounts array" '"Accounts"' \
+  "$BIN" accounts --format json
+
+assert_ok   "IDC: whoami --format text exits 0" "$BIN" whoami --format text
+assert_json "IDC: whoami --format json is valid JSON" "$BIN" whoami --format json
+IDC_WHOAMI=$("$BIN" whoami --format json 2>/dev/null)
+for field in AccountID Domain Environment Quality Role User; do
+  val=$(echo "$IDC_WHOAMI" | json_field "$field")
+  [[ -n "$val" ]] && pass "IDC: whoami has $field" || fail "IDC: whoami missing $field"
+done
+
+# ── Section 4: USE_SUBSTRATE=true escape hatch ───────────────────────────────
+
+section "USE_SUBSTRATE=true escape hatch (IDC configured, forcing Substrate)"
+
+idc_clear_creds
+rm -f ~/.quikstrate/credentials.json
+
+env USE_SUBSTRATE=true "$BIN" credentials --force --format json > /dev/null 2>&1
+assert_ok "Escape hatch: credentials.json written when USE_SUBSTRATE=true overrides IDC config" \
+  test -f ~/.quikstrate/credentials.json
+
+if [[ -f ~/.quikstrate/credentials-idc.json ]]; then
+  creds_mtime=$(stat -f %m ~/.quikstrate/credentials.json 2>/dev/null || stat -c %Y ~/.quikstrate/credentials.json 2>/dev/null)
+  idc_mtime=$(stat -f %m ~/.quikstrate/credentials-idc.json 2>/dev/null || stat -c %Y ~/.quikstrate/credentials-idc.json 2>/dev/null)
+  [[ "$creds_mtime" -ge "$idc_mtime" ]] \
+    && pass "Escape hatch: credentials-idc.json not freshly written when USE_SUBSTRATE=true" \
+    || fail "Escape hatch: credentials-idc.json appears freshly written despite USE_SUBSTRATE=true"
+else
+  pass "Escape hatch: credentials-idc.json does not exist"
+fi
+
+# ── Section 5: configure --use-substrate (revert) ────────────────────────────
+
+section "configure --use-substrate (revert to Substrate)"
+
+assert_ok "configure --use-substrate exits 0" "$BIN" configure --use-substrate
+
+cfg_after=$(python3 -c "import json; print(json.load(open('$HOME/.quikstrate/config.json')).get('credential_source',''))")
+[[ "$cfg_after" == "substrate" ]] \
+  && pass "config.json reverted to credential_source=substrate" \
+  || fail "config.json has unexpected credential_source=$cfg_after after --use-substrate"
+
+idc_clear_creds
+rm -f ~/.quikstrate/credentials.json
+"$BIN" credentials --force --format json > /dev/null 2>&1
+assert_ok "After --use-substrate, credentials writes credentials.json" \
+  test -f ~/.quikstrate/credentials.json
+
+IDC_MTIME=$(stat -f %m ~/.quikstrate/credentials-idc.json 2>/dev/null \
+  || stat -c %Y ~/.quikstrate/credentials-idc.json 2>/dev/null || echo 0)
+SUB_MTIME=$(stat -f %m ~/.quikstrate/credentials.json 2>/dev/null \
+  || stat -c %Y ~/.quikstrate/credentials.json 2>/dev/null || echo 1)
+[[ "$IDC_MTIME" -lt "$SUB_MTIME" ]] \
+  && pass "credentials-idc.json not freshly written after configure --use-substrate" \
+  || fail "credentials-idc.json appears freshly written after configure --use-substrate"
+
+# ── summary ───────────────────────────────────────────────────────────────────
+echo
+echo "════════════════════════════════════════════════"
+printf "  PASS: %d   FAIL: %d   SKIP: %d\n" "$PASS" "$FAIL" "$SKIP"
+echo "════════════════════════════════════════════════"
+
+if [[ ${#FAILURES[@]} -gt 0 ]]; then
+  echo
+  echo "Failed tests:"
+  for f in "${FAILURES[@]}"; do
+    echo "  - $f"
+  done
+  exit 1
+fi
+
+exit 0

--- a/scripts/identitycenter_test.sh
+++ b/scripts/identitycenter_test.sh
@@ -106,6 +106,22 @@ idc_clear_creds() {
   rm -f ~/.quikstrate/*-idc.json 2>/dev/null || true
 }
 
+# Remove every cache file (Substrate and IDC) for the env/domain and special
+# account fixtures below, so leftovers from earlier runs — including runs of
+# the real quikstrate binary against the same accounts — can't be mistaken
+# for files this run wrote.
+clear_fixture_caches() {
+  local key acct_env acct_domain
+  for key in "${!SERVICE_ACCOUNTS[@]}"; do
+    acct_env="${key%%-*}"
+    acct_domain="${key#*-}"
+    rm -f ~/.quikstrate/"${acct_env}-${acct_domain}"-*.json 2>/dev/null || true
+  done
+  for key in "${!SPECIAL_ACCOUNTS[@]}"; do
+    rm -f ~/.quikstrate/special-"${key}"-*.json 2>/dev/null || true
+  done
+}
+
 section() { echo; echo "── $1 ──────────────────────────────────────────────"; }
 
 # ── account fixtures ──────────────────────────────────────────────────────────
@@ -144,6 +160,9 @@ fi
 echo "  AWS identity: $(aws sts get-caller-identity --query Arn --output text)"
 
 echo "  IDC: login will be triggered automatically on first credential fetch if needed"
+
+clear_fixture_caches
+echo "  cleared cached credentials for fixture accounts"
 
 # Save the original config so it can be restored on exit regardless of outcome.
 SAVED_CONFIG=""
@@ -289,9 +308,11 @@ for key in "${!SERVICE_ACCOUNTS[@]}"; do
 
   rm -f ~/.quikstrate/"${acct_env}-${acct_domain}"-*-idc.json 2>/dev/null || true
 
-  json=$("$BIN" assume -e "$acct_env" -d "$acct_domain" $ROLE_FLAG --format json 2>/dev/null) || {
-    fail "$prefix — command failed"; continue
+  err=$(mktemp)
+  json=$("$BIN" assume -e "$acct_env" -d "$acct_domain" $ROLE_FLAG --format json 2>"$err") || {
+    fail "$prefix — command failed — $(tail -2 "$err" | tr '\n' ' ')"; rm -f "$err"; continue
   }
+  rm -f "$err"
   echo "$json" | python3 -m json.tool > /dev/null 2>&1 || { fail "$prefix — invalid JSON"; continue; }
 
   actual=$(aws_account_for_creds "$json") || { fail "$prefix — sts failed"; continue; }
@@ -321,26 +342,30 @@ section "IDC: role normalization"
 if [[ "$ENGINEERSREADONLY" == "true" ]]; then
   skip "IDC: --role Administrator normalizes to admin (pass without --engineersreadonly)"
 else
-  norm_json=$("$BIN" assume -e staging -d api --role Administrator --format json 2>/dev/null) || true
+  err=$(mktemp)
+  norm_json=$("$BIN" assume -e staging -d api --role Administrator --format json 2>"$err") || true
   if echo "$norm_json" | python3 -m json.tool > /dev/null 2>&1; then
     norm_acct=$(aws_account_for_creds "$norm_json")
     [[ "$norm_acct" == "407752757973" ]] \
       && pass "IDC: --role Administrator normalizes to admin (407752757973)" \
       || fail "IDC: --role Administrator — wrong account $norm_acct"
   else
-    fail "IDC: --role Administrator returned invalid JSON"
+    fail "IDC: --role Administrator returned invalid JSON — $(tail -2 "$err" | tr '\n' ' ')"
   fi
+  rm -f "$err"
 fi
 
-aud_json=$("$BIN" assume -e prod -d api --role Auditor --format json 2>/dev/null) || true
+err=$(mktemp)
+aud_json=$("$BIN" assume -e prod -d api --role Auditor --format json 2>"$err") || true
 if echo "$aud_json" | python3 -m json.tool > /dev/null 2>&1; then
   aud_acct=$(aws_account_for_creds "$aud_json")
   [[ "$aud_acct" == "477056945755" ]] \
     && pass "IDC: --role Auditor normalizes to engineersreadonly (477056945755)" \
     || fail "IDC: --role Auditor — wrong account $aud_acct"
 else
-  fail "IDC: --role Auditor returned invalid JSON"
+  fail "IDC: --role Auditor returned invalid JSON — $(tail -2 "$err" | tr '\n' ' ')"
 fi
+rm -f "$err"
 
 section "IDC: special accounts"
 

--- a/scripts/regression_test.sh
+++ b/scripts/regression_test.sh
@@ -64,7 +64,7 @@ assert_output() {
 assert_json() {
   local desc="$1"; shift
   local out
-  out=$("$@" 2>&1)
+  out=$("$@" 2>/dev/null)
   local code=$?
   if [[ $code -ne 0 ]]; then
     fail "$desc — exit $code"
@@ -81,15 +81,24 @@ json_field() { python3 -c "import sys,json; print(json.load(sys.stdin).get('$1',
 section() { echo; echo "── $1 ──────────────────────────────────────────────"; }
 
 # ── account sample ────────────────────────────────────────────────────────────
-# Representative assume-role targets: staging, prod, and the prod-only domain.
-# Source: metronome-substrate/substrate.accounts.txt
 # Key format: "<env>-<domain>"  Value: expected AWS account ID
+# Source: internal/creds/accounts.go
 declare -A SERVICE_ACCOUNTS=(
   ["staging-api"]="407752757973"
   ["staging-graphql"]="008444403661"
+  ["staging-integrations"]="637423284925"
+  ["staging-network-staging"]="075647413734"
   ["prod-api"]="477056945755"
   ["prod-graphql"]="051318803586"
+  ["prod-integrations"]="533267210102"
   ["prod-internal-services"]="207567762512"  # prod-only; staging variant must fail
+)
+
+declare -A SPECIAL_ACCOUNTS=(
+  ["management"]="420073272039"
+  ["audit"]="465454680116"
+  ["deploy"]="703712742941"
+  ["network"]="814412579886"
 )
 
 # Fields required by the AWS credential_process spec (fixed by AWS SDK, cannot change)
@@ -108,10 +117,20 @@ fi
 echo "  binary: $(command -v "$BIN")"
 
 if ! aws sts get-caller-identity > /dev/null 2>&1; then
-  echo "ERROR: No working AWS credentials. Source credentials before running."
+  echo "ERROR: No working AWS credentials."
+  echo "       Run: eval \$($BIN credentials --format export)"
   exit 1
 fi
 echo "  AWS identity: $(aws sts get-caller-identity --query Arn --output text)"
+
+# Clear the credential cache so every fetch in this run goes through the binary
+# under test. Without this, stale files from a previous run (or the installed
+# binary) can mask broken credential-fetch paths.
+if "$BIN" clean 2>/dev/null; then
+  echo "  cache cleared"
+else
+  echo "  WARN  cache clear failed; tests may use stale credentials"
+fi
 
 # ── configure ─────────────────────────────────────────────────────────────────
 # Runs first when --run-configure is passed so all subsequent tests use the
@@ -189,6 +208,8 @@ assert_fail "assume --domain only exits non-zero (missing --env)" "$BIN" assume 
 assert_fail "assume with invalid --env exits non-zero" "$BIN" assume --env badenv --domain api
 assert_fail "assume staging/internal-services exits non-zero (account does not exist)" \
   "$BIN" assume -e staging -d internal-services
+assert_fail "assume --management --special exits non-zero (mutually exclusive)" \
+  "$BIN" assume --management --special audit
 
 # Test a single env/domain: validate credential shape and verify the right AWS account
 test_assume() {
@@ -238,6 +259,41 @@ for key in "${!SERVICE_ACCOUNTS[@]}"; do
   test_assume "$acct_env" "$acct_domain" "${SERVICE_ACCOUNTS[$key]}"
 done
 
+section "assume: -f short flag"
+assert_json "assume -e staging -d api -f json is valid JSON" \
+  "$BIN" assume -e staging -d api -f json
+assert_json "assume --management -f json is valid JSON" \
+  "$BIN" assume --management -f json
+assert_json "credentials -f json is valid JSON" \
+  "$BIN" credentials -f json
+
+section "assume: --management and --special"
+test_assume_special() {
+  local name="$1" expected_account="$2"
+  local prefix="assume --special $name"
+  local json key secret token actual_account
+
+  json=$("$BIN" assume --special "$name" --format json 2>/dev/null) || {
+    fail "$prefix — command failed"; return
+  }
+  echo "$json" | python3 -m json.tool > /dev/null 2>&1 || { fail "$prefix — invalid JSON"; return; }
+
+  key=$(echo "$json" | json_field AccessKeyId)
+  secret=$(echo "$json" | json_field SecretAccessKey)
+  token=$(echo "$json" | json_field SessionToken)
+  actual_account=$(AWS_ACCESS_KEY_ID="$key" AWS_SECRET_ACCESS_KEY="$secret" AWS_SESSION_TOKEN="$token" \
+    aws sts get-caller-identity --query Account --output text 2>/dev/null) || {
+    fail "$prefix — sts get-caller-identity failed"; return
+  }
+  [[ "$actual_account" == "$expected_account" ]] \
+    && pass "$prefix — correct account ($actual_account)" \
+    || fail "$prefix — wrong account: got $actual_account, expected $expected_account"
+}
+
+for name in "${!SPECIAL_ACCOUNTS[@]}"; do
+  test_assume_special "$name" "${SPECIAL_ACCOUNTS[$name]}"
+done
+
 # ── accounts ─────────────────────────────────────────────────────────────────
 section "accounts"
 
@@ -246,6 +302,8 @@ assert_json "accounts --format json is valid JSON" "$BIN" accounts --format json
 assert_output "accounts --format json has Accounts array" '"Accounts"' "$BIN" accounts --format json
 assert_output "accounts --format json contains staging accounts" "staging" "$BIN" accounts --format json
 assert_output "accounts --format json contains prod accounts" "prod" "$BIN" accounts --format json
+assert_output "accounts --format text includes integrations" "integrations" "$BIN" accounts --format text
+assert_output "accounts --format text includes network-staging" "network-staging" "$BIN" accounts --format text
 
 # ── whoami ────────────────────────────────────────────────────────────────────
 section "whoami"
@@ -294,8 +352,15 @@ fi
 
 # ── clean ─────────────────────────────────────────────────────────────────────
 section "clean"
-echo "  INFO  Skipped to preserve credential cache from this run."
-echo "        To test manually: quikstrate clean && quikstrate credentials"
+
+# Populate a special-account cache file then verify clean removes it and a
+# subsequent fetch succeeds (tests the special-<name>-<role>.json naming).
+"$BIN" assume --special audit --format json > /dev/null 2>&1
+assert_ok "clean exits 0" "$BIN" clean
+assert_fail "special-account cache file removed after clean" \
+  bash -c "ls ~/.quikstrate/special-audit-*.json > /dev/null 2>&1"
+assert_json "assume --special audit works after clean (re-fetches)" \
+  "$BIN" assume --special audit --format json
 
 # ── summary ───────────────────────────────────────────────────────────────────
 echo

--- a/scripts/regression_test.sh
+++ b/scripts/regression_test.sh
@@ -4,7 +4,7 @@
 # work against the expected AWS accounts. All AWS calls are read-only.
 #
 # Usage:
-#   ./scripts/regression_test.sh [--run-configure] [--run-drift]
+#   ./scripts/regression_test.sh [--run-configure]
 #
 #   --run-configure  Write real ~/.aws/config and ~/.kube/config, then verify
 #                    a sample of AWS_PROFILE values work end-to-end.


### PR DESCRIPTION
Add Metronome IAM Identity Center as an opt-in credential source. This is Crawl stage of a [Crawl, Walk, Run plan](https://docs.google.com/document/d/1dnqNDbDVzoKWjflu4RfNnWgf8EFZRNOyUlrpsbiy5P4/edit?tab=t.0) migration Metronome AWS accounts into the Stripe AWS Organization and Stripe IAM Identity Center. 

[AWS IAM Identity Center](https://aws.amazon.com/iam/identity-center/) is already deployed in Metronome AWS. This PR adds an optional path in quikstrate to use that Identity Center instance.

Opt in controlled by running `quikstrate configure --use-identitycenter` to set the credential source in `config.json`. There should be no functional change to how quikstrate commands run from a user point of view. Credentials can be used the same way, they are just sourced from Identity Center instead of Substrate. 

Using Identity Center can be reverted with `quikstrate configure --use-substrate` or for one-off commands by setting  `USE_SUBSTRATE=true`

I have bash scripts generated by Claude Code that show what I covered in testing the CLI locally to make sure role assumption behaviour still acts as expected. 

As we test this I will have follow up PRs to make sure all workflows continue working, but this is a start to get testing the credential source and can switch between Substrate and Identity Center