### PR TITLE
Update homebrew to use pull request

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,6 +26,8 @@ brews:
       owner: Metronome-Industries
       name: homebrew-metronome
       branch: main
+      pull_request:
+        enabled: true
     directory: Formula
     homepage: https://github.com/Metronome-Industries/{{ .ProjectName }} 
     dependencies:


### PR DESCRIPTION
- The homebrew-metronome repo now has a branch protection rule requiring all changes go through a PR. 
- GoReleaser was doing a direct commit to main, which now returns 409, [failing publish step](https://app.circleci.com/pipelines/gh/Metronome-Industries/quikstrate/228/details?utm_campaign=workflowcompleted_failed&utm_medium=notification&utm_content=workflowurl_workflow-email&utm_source=email&workflowId=253ac45e-527e-47ae-a9c4-ac75b294a747&job=564aea7f-43f2-4c64-b5ee-4fad3307fd65&buildNumber=243&jobType=build#step-107-) for my last [merge](https://github.com/Metronome-Industries/quikstrate/pull/31)
- Adding pull_request.enabled: true, so GoReleaser will instead fork off a branch and open a PR against main
- Following releases will create a PR in homebrew-metronome repo that will need to be merged, but this is similar to flow for other repos ([upgrading-substrate-tools.md](https://stripe.sourcegraphcloud.com/r/Metronome-Industries/homebrew-metronome@baba12ed5d73cfcfbabb8e1e0e09fc54234a416b/-/blob/upgrading-substrate-tools.md))