### PR TITLE
Remove homebrew publish step

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -21,16 +21,3 @@ archives:
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
 
-brews:
-  - repository:
-      owner: Metronome-Industries
-      name: homebrew-metronome
-      branch: main
-    directory: Formula
-    homepage: https://github.com/Metronome-Industries/{{ .ProjectName }} 
-    dependencies:
-      - name: metronome-industries/metronome/substrate-tools
-      - name: kubectl
-      - name: kubectx
-      - name: awscli
-        type: optional


### PR DESCRIPTION
This might not be the right solution, but the homebrew publishing step [no longer works](https://app.circleci.com/pipelines/gh/Metronome-Industries/quikstrate/228/details?utm_campaign=workflowcompleted_failed&utm_medium=notification&utm_content=workflowurl_workflow-email&utm_source=email&workflowId=253ac45e-527e-47ae-a9c4-ac75b294a747&job=564aea7f-43f2-4c64-b5ee-4fad3307fd65&buildNumber=243&jobType=build#step-107-) since it relies on direct push to main and the homebrew-metronome repo now has a branch protection rule requiring all changes go through a PR.

I tried adding pull_request.enabled: true, so GoReleaser would instead fork off a branch ([PR](https://github.com/Metronome-Industries/quikstrate/pull/33)), but that still [failed](https://app.circleci.com/pipelines/gh/Metronome-Industries/quikstrate/231/details?utm_campaign=workflowcompleted_failed&utm_medium=notification&utm_content=workflowurl_workflow-email&utm_source=email&workflowId=76693cdc-b142-4cd1-8759-62739100180e&job=2b236273-ee29-407f-8b88-4b60fec2cc60&buildNumber=246&jobType=build#step-107-). 

Circle CI error
```log
      • release created/updated                      url=https://github.com/Metronome-Industries/quikstrate/releases/tag/1.0.30 published=true
      • took: 2s
    • homebrew tap formula
      • error checking for default branch            projectID= statusCode=404 error=GET https://api.github.com/repos//: 404 Not Found []
      • could not sync fork                          error=GET https://api.github.com/repos//: 404 Not Found []
      • pushing                                      repository=Metronome-Industries/homebrew-metronome branch=main file=Formula/quikstrate.rb
      • took: 1s
  • took: 3s
  ⨯ release failed after 1m3s                error=1 error occurred:
        * homebrew tap formula: could not update "Formula/quikstrate.rb": PUT https://api.github.com/repos/Metronome-Industries/homebrew-metronome/contents/Formula/quikstrate.rb: 409 Could not update file: Changes must be made through a pull request. []
```

## Alternative to consider

- Maintaining this auto-publish step probably includes provisioning a new PAT with permissions it needs to create a branch & PR and updating the config to do so, but someone still needs to approve and merge that PR
- For now I have cut a manual PR (well actually Claude did drafted the PR) to update the homebrew tap https://github.com/Metronome-Industries/homebrew-metronome/pull/56