### PR TITLE
creds command should use admin

### DIFF
--- a/internal/creds/credentials.go
+++ b/internal/creds/credentials.go
@@ -118,7 +118,7 @@ func getCredentials(role RoleData) (Credentials, error) {
 
 func getIDCCredentials(role RoleData) (Credentials, error) {
 	if role == (RoleData{}) {
-		return getMetronomeSSORoleCredentials(staticSpecialAccounts["substrate"], idcRoleReadOnly)
+		return getMetronomeSSORoleCredentials(staticSpecialAccounts["substrate"], idcRoleAdmin)
 	}
 
 	if role.SpecialAccount != "" {


### PR DESCRIPTION
i understand why we want this to be readonly, but the credentials command is integrated into many folk's workflows, and switching to this to readonly is going to be pretty annoying
